### PR TITLE
修改邀请好友点击区域

### DIFF
--- a/tasks/Hyakkiyakou/assets.py
+++ b/tasks/Hyakkiyakou/assets.py
@@ -18,9 +18,9 @@ class HyakkiyakouAssets:
 	# description 
 	C_HSELECT_3 = RuleClick(roi_front=(934,298,115,306), roi_back=(934,298,115,306), name="hselect_3")
 	# description 
-	C_FRIEND_1 = RuleClick(roi_front=(446,227,181,67), roi_back=(446,227,181,67), name="friend_1")
+	C_FRIEND_1 = RuleClick(roi_front=(466,227,161,67), roi_back=(466,227,161,67), name="friend_1")
 	# description 
-	C_FRIEND_2 = RuleClick(roi_front=(718,229,178,64), roi_back=(718,229,178,64), name="friend_2")
+	C_FRIEND_2 = RuleClick(roi_front=(738,229,158,64), roi_back=(738,229,158,64), name="friend_2")
 	# description 
 	C_FRIEND_3 = RuleClick(roi_front=(445,310,183,66), roi_back=(445,310,183,66), name="friend_3")
 	# description 

--- a/tasks/Hyakkiyakou/hya/click.json
+++ b/tasks/Hyakkiyakou/hya/click.json
@@ -19,14 +19,14 @@
   },
   {
     "itemName": "friend_1",
-    "roiFront": "446,227,181,67",
-    "roiBack": "446,227,181,67",
+    "roiFront": "466,227,161,67",
+    "roiBack": "466,227,161,67",
     "description": "description"
   },
   {
     "itemName": "friend_2",
-    "roiFront": "718,229,178,64",
-    "roiBack": "718,229,178,64",
+    "roiFront": "738,229,158,64",
+    "roiBack": "738,229,158,64",
     "description": "description"
   },
   {


### PR DESCRIPTION
有些头像框过于张牙舞爪，看图片只是点中了红色区域左上角的坐标压根碰不到头像框，但依然能点出来弹窗。现在统一往右缩了 20 像素，以后人名第一个字位置还是不要框选上了，沾边就容易误点。
> 2024-07-02 23:56:40.853 |     INFO | INVITE FRIEND                              
2024-07-02 23:56:41.153 |     INFO | Click ( 164,  573) @ HYA_HINVITE           
2024-07-02 23:56:42.358 |     INFO | Click ( 446,  255) @ friend_1              
2024-07-02 23:56:42.657 |     INFO | Click ( 753,  260) @ friend_2              
2024-07-02 23:56:44.468 |     INFO | Click ( 456,  268) @ friend_1              
2024-07-02 23:56:45.977 |     INFO | Click ( 816,  229) @ friend_2              
2024-07-02 23:56:46.577 |     INFO | Click ( 547,  261) @ friend_1              
2024-07-02 23:56:48.683 |     INFO | Click ( 556,  278) @ friend_1              
2024-07-02 23:56:49.287 |     INFO | Click ( 776,  273) @ friend_2              
2024-07-02 23:56:50.189 |  WARNING | Invite friend timeout, It may be no friend 
available                                                                       
2024-07-02 23:56:50.190 |     INFO | Invite different server friend             
2024-07-02 23:57:49.539 |  WARNING | Wait too long                              
2024-07-02 23:57:49.541 |  WARNING | Waiting for set()                          
2024-07-02 23:57:49.621 |     INFO | [Package_name]                             
com.netease.onmyoji.wyzymnqsd_cps                                               
2024-07-02 23:57:49.622 |    ERROR | GameStuckError: Wait too long              

![2024-07-02_23-57-48-937571-0](https://github.com/runhey/OnmyojiAutoScript/assets/25378493/7912dfcb-5359-48d6-9d5c-a22fff5df1b1)
