### PR TITLE
修复“组队邀请过于频繁，请稍后再发”

### DIFF
--- a/tasks/Component/GeneralInvite/general_invite.py
+++ b/tasks/Component/GeneralInvite/general_invite.py
@@ -468,6 +468,7 @@ class GeneralInvite(BaseTask, GeneralInviteAssets):
             logger.warning('Invite friend 1 failed')
         # 如果是邀请第二个人
         if config.invite_number == InviteNumber.TWO:
+            sleep(5)
             success = self.invite_friend(config.friend_2, config.find_mode)
             if not success:
                 logger.warning('Invite friend 2 failed')


### PR DESCRIPTION
连续邀请的间隔实测最短 5 秒，干脆也别卡秒了直接多等会儿吧