### PR TITLE
fix(SwitchSoul)切换御魂卡住

### DIFF
--- a/dev_tools/assets_test.py
+++ b/dev_tools/assets_test.py
@@ -34,10 +34,11 @@ def detect_ocr(file: str, target: RuleOcr):
 
 
 # 图片文件路径 可以是相对路径
-IMAGE_FILE = r"C:\Users\萌萌哒\Desktop\341978692-fdceb33c-eec1-4965-a2b9-8f75cd54d5e2.png"
+IMAGE_FILE = r"C:\Users\萌萌哒\Desktop\349772746-36423909-af3d-4d9c-bae4-9d2597e2ecda.png"
 if __name__ == '__main__':
     from tasks.RyouToppa.assets import RyouToppaAssets
-    targe = RyouToppaAssets.I_RYOU_TOPPA
+    from tasks.GameUi.assets import GameUiAssets
+    targe = GameUiAssets.I_MAIN_GOTO_GUILD
     print(detect_image(IMAGE_FILE, targe))
 
     # ocr demo

--- a/tasks/GameUi/assets.py
+++ b/tasks/GameUi/assets.py
@@ -127,21 +127,21 @@ class GameUiAssets:
 
 	# Image Rule Assets
 	# 式神录 
-	I_MAIN_GOTO_SHIKIGAMI_RECORDS = RuleImage(roi_front=(1098,611,56,64), roi_back=(1084,589,93,106), threshold=0.8, method="Template matching", file="./tasks/GameUi/page/page_main_goto_shikigami_records.png")
+	I_MAIN_GOTO_SHIKIGAMI_RECORDS = RuleImage(roi_front=(1098,611,56,64), roi_back=(1084,589,93,106), threshold=0.7, method="Template matching", file="./tasks/GameUi/page/page_main_goto_shikigami_records.png")
 	# description 
 	I_MAIN_GOTO_ONMYODO = RuleImage(roi_front=(992,614,51,60), roi_back=(992,614,51,60), threshold=0.8, method="Template matching", file="./tasks/GameUi/page/page_main_goto_onmyodo.png")
 	# description 
-	I_MAIN_GOTO_FRIENDS = RuleImage(roi_front=(879,623,55,55), roi_back=(867,606,79,77), threshold=0.8, method="Template matching", file="./tasks/GameUi/page/page_main_goto_friends.png")
+	I_MAIN_GOTO_FRIENDS = RuleImage(roi_front=(879,623,55,55), roi_back=(867,606,79,77), threshold=0.7, method="Template matching", file="./tasks/GameUi/page/page_main_goto_friends.png")
 	# 进入花合战 
 	I_MAIN_GOTO_DAILY = RuleImage(roi_front=(779,612,51,67), roi_back=(754,595,89,97), threshold=0.7, method="Template matching", file="./tasks/GameUi/page/page_main_goto_daily.png")
 	# description 
 	I_MAIN_GOTO_MALL = RuleImage(roi_front=(663,661,41,22), roi_back=(644,613,81,78), threshold=0.7, method="Template matching", file="./tasks/GameUi/page/page_main_goto_mall.png")
 	# description 
-	I_MAIN_GOTO_GUILD = RuleImage(roi_front=(540,611,50,54), roi_back=(540,611,50,54), threshold=0.8, method="Template matching", file="./tasks/GameUi/page/page_main_goto_guild.png")
+	I_MAIN_GOTO_GUILD = RuleImage(roi_front=(540,611,50,54), roi_back=(540,611,50,54), threshold=0.7, method="Template matching", file="./tasks/GameUi/page/page_main_goto_guild.png")
 	# description 
-	I_MAIN_GOTO_TEAM = RuleImage(roi_front=(437,625,38,48), roi_back=(366,606,192,83), threshold=0.8, method="Template matching", file="./tasks/GameUi/page/page_main_goto_team.png")
+	I_MAIN_GOTO_TEAM = RuleImage(roi_front=(437,625,38,48), roi_back=(366,606,192,83), threshold=0.7, method="Template matching", file="./tasks/GameUi/page/page_main_goto_team.png")
 	# description 
-	I_MAIN_GOTO_COLLECTION = RuleImage(roi_front=(92,621,36,41), roi_back=(51,596,159,85), threshold=0.8, method="Template matching", file="./tasks/GameUi/page/page_main_goto_collection.png")
+	I_MAIN_GOTO_COLLECTION = RuleImage(roi_front=(92,621,36,41), roi_back=(51,596,159,85), threshold=0.7, method="Template matching", file="./tasks/GameUi/page/page_main_goto_collection.png")
 	# description 
 	I_CHECK_RECORDS = RuleImage(roi_front=(269,71,55,50), roi_back=(269,71,55,50), threshold=0.8, method="Template matching", file="./tasks/GameUi/page/page_check_records.png")
 	# description 

--- a/tasks/GameUi/page/page_img_3.json
+++ b/tasks/GameUi/page/page_img_3.json
@@ -5,7 +5,7 @@
     "roiFront": "1098,611,56,64",
     "roiBack": "1084,589,93,106",
     "method": "Template matching",
-    "threshold": 0.8,
+    "threshold": 0.7,
     "description": "式神录"
   },
   {
@@ -23,7 +23,7 @@
     "roiFront": "879,623,55,55",
     "roiBack": "867,606,79,77",
     "method": "Template matching",
-    "threshold": 0.8,
+    "threshold": 0.7,
     "description": "description"
   },
   {
@@ -50,7 +50,7 @@
     "roiFront": "540,611,50,54",
     "roiBack": "540,611,50,54",
     "method": "Template matching",
-    "threshold": 0.8,
+    "threshold": 0.7,
     "description": "description"
   },
   {
@@ -59,7 +59,7 @@
     "roiFront": "437,625,38,48",
     "roiBack": "366,606,192,83",
     "method": "Template matching",
-    "threshold": 0.8,
+    "threshold": 0.7,
     "description": "description"
   },
   {
@@ -68,7 +68,7 @@
     "roiFront": "92,621,36,41",
     "roiBack": "51,596,159,85",
     "method": "Template matching",
-    "threshold": 0.8,
+    "threshold": 0.7,
     "description": "description"
   },
   {


### PR DESCRIPTION
修复切换御魂时 只会滑动一次的BUG, 现在可以正确的滑动到最顶部
由于多开模拟器卡顿造成的:
   1. 预设按钮多次点击造成切换御魂失败
   2. 切换御魂出现的确定对话框无法关闭导致的卡死