### PR TITLE
修复未设置浮动时间的固定时间范围

### DIFF
--- a/module/config/utils.py
+++ b/module/config/utils.py
@@ -258,16 +258,17 @@ def parse_tomorrow_server(server_update: time, float_seconds: int = 0) -> dateti
     next_run = datetime.combine(tomorrow, server_update)
     
     # 应用浮动时间
-    next_run += timedelta(seconds=float_seconds)
+    if float_seconds !=0:
+        next_run += timedelta(seconds=float_seconds)
+
+        # 确保时间在第二天内，不回退到前一天，不跨越到第三天（考虑任务时间，最早 00:00，最晚 23:50）
+        start_of_tomorrow = datetime.combine(tomorrow, time.min)
+        end_of_tomorrow = datetime.combine(tomorrow, time(hour=23, minute=50))
     
-    # 确保时间在第二天内，不回退到前一天，不跨越到第三天（考虑任务时间，最早 00:00，最晚 23:50）
-    start_of_tomorrow = datetime.combine(tomorrow, time.min)
-    end_of_tomorrow = datetime.combine(tomorrow, time(hour=23, minute=50))
-    
-    if next_run < start_of_tomorrow:
-        next_run = start_of_tomorrow
-    elif next_run > end_of_tomorrow:
-        next_run = end_of_tomorrow
+        if next_run < start_of_tomorrow:
+            next_run = start_of_tomorrow
+        elif next_run > end_of_tomorrow:
+            next_run = end_of_tomorrow
     
     return next_run
 

--- a/tasks/Component/config_scheduler.py
+++ b/tasks/Component/config_scheduler.py
@@ -16,7 +16,7 @@ class Scheduler(ConfigBase):
     success_interval: TimeDelta = Field(default=TimeDelta(days=1), description='success_interval_help')
     failure_interval: TimeDelta = Field(default=TimeDelta(days=1), description='failure_interval_help')
     server_update: Time = Field(default=Time(hour=9, minute=0, second=0), description='server_update_help')
-    float_time: Time = Field(default=Time(hour=0, minute=0, second=0), description='float_time_help')
+    float_time: Time = Field(default=Time(hour=0, minute=0, second=0), description='下次运行时间将在此范围内随机浮动。未设强制执行时，推荐浮动小于间隔：如寮突30±5分钟，寄养6±0.2小时；有强制执行时，确保不超出窗口：如麒麟19:01±1分钟，逢魔18:00±0.5小时，避免影响其他任务')
 
     @validator('next_run', pre=True, always=True)
     def parse_next_run(cls, value):

--- a/tasks/Component/config_scheduler.py
+++ b/tasks/Component/config_scheduler.py
@@ -16,7 +16,7 @@ class Scheduler(ConfigBase):
     success_interval: TimeDelta = Field(default=TimeDelta(days=1), description='success_interval_help')
     failure_interval: TimeDelta = Field(default=TimeDelta(days=1), description='failure_interval_help')
     server_update: Time = Field(default=Time(hour=9, minute=0, second=0), description='server_update_help')
-    float_time: Time = Field(default=Time(hour=0, minute=0, second=0), description='下次运行时间将在此范围内随机浮动。未设强制执行时，推荐浮动小于间隔：如寮突30±5分钟，寄养6±0.2小时；有强制执行时，确保不超出窗口：如麒麟19:01±1分钟，逢魔18:00±0.5小时，避免影响其他任务')
+    float_time: Time = Field(default=Time(hour=0, minute=0, second=0), description='float_time_help')
 
     @validator('next_run', pre=True, always=True)
     def parse_next_run(cls, value):


### PR DESCRIPTION
顺便修复了个问题：如果没有设置浮动时间，可以使时间设定在 23:51-23:59 之间。毕竟这是用户的自由
要不然推荐值你放文档里吧，放界面里挺啰嗦的