### PR TITLE
接受邀请后立即去完成悬赏

### DIFF
--- a/tasks/GlobalGame/config_emergency.py
+++ b/tasks/GlobalGame/config_emergency.py
@@ -15,10 +15,6 @@ class FriendInvitation(str, Enum):
     JADE_AND_FOOD = 'jade_and_food' # 勾协+粮协
     IGNORE = 'ignore'
 
-class WhenAcceptInvitation(str, Enum):
-    # 接取悬赏后立即去完成，默认关闭
-    accept_invitation_complete_now: bool = Field(default=False)
-
 class WhenNetworkAbnormal(str, Enum):
     RESTART = 'restart'
     WAIT_10S = 'wait_10s'
@@ -29,7 +25,6 @@ class WhenNetworkError(str, Enum):
 # 也可以是左边的邀请什么的
 class Emergency(BaseModel):
     friend_invitation: FriendInvitation = Field(default=FriendInvitation.ACCEPT,description='friend_invitation_help')
-    when_accept_invitation: WhenAcceptInvitation = Field(default_factory=WhenAcceptInvitation)
     # invitation_detect_interval: int = Field(default=5, description='invitation_detect_interval_help')
     when_network_abnormal: WhenNetworkAbnormal = Field(default=WhenNetworkAbnormal.WAIT_10S, description='when_network_abnormal_help')
     when_network_error: WhenNetworkError = Field(default=WhenNetworkError.RESTART, description='when_network_error_help')

--- a/tasks/GlobalGame/config_emergency.py
+++ b/tasks/GlobalGame/config_emergency.py
@@ -15,6 +15,10 @@ class FriendInvitation(str, Enum):
     JADE_AND_FOOD = 'jade_and_food' # 勾协+粮协
     IGNORE = 'ignore'
 
+class WhenAcceptInvitation(str, Enum):
+    # 接取悬赏后立即去完成，默认关闭
+    accept_invitation_complete_now: bool = Field(default=False)
+
 class WhenNetworkAbnormal(str, Enum):
     RESTART = 'restart'
     WAIT_10S = 'wait_10s'
@@ -25,6 +29,7 @@ class WhenNetworkError(str, Enum):
 # 也可以是左边的邀请什么的
 class Emergency(BaseModel):
     friend_invitation: FriendInvitation = Field(default=FriendInvitation.ACCEPT,description='friend_invitation_help')
+    when_accept_invitation: WhenAcceptInvitation = Field(default_factory=WhenAcceptInvitation)
     # invitation_detect_interval: int = Field(default=5, description='invitation_detect_interval_help')
     when_network_abnormal: WhenNetworkAbnormal = Field(default=WhenNetworkAbnormal.WAIT_10S, description='when_network_abnormal_help')
     when_network_error: WhenNetworkError = Field(default=WhenNetworkError.RESTART, description='when_network_error_help')

--- a/tasks/base_task.py
+++ b/tasks/base_task.py
@@ -25,7 +25,7 @@ from module.config.config import Config
 from module.config.utils import get_server_next_update, nearest_future, dict_to_kv, parse_tomorrow_server
 from module.device.device import Device
 from tasks.GlobalGame.assets import GlobalGameAssets
-from tasks.GlobalGame.config_emergency import FriendInvitation, WhenAcceptInvitation, WhenNetworkAbnormal, WhenNetworkError
+from tasks.GlobalGame.config_emergency import FriendInvitation, WhenNetworkAbnormal, WhenNetworkError
 from tasks.Component.Costume.costume_base import CostumeBase
 
 from module.exception import GameStuckError, ScriptError
@@ -114,7 +114,8 @@ class BaseTask(GlobalGameAssets, CostumeBase):
                 continue
         # 有的时候长战斗 点击后会取消战斗状态
         self.device.detect_record = detect_record
-        if WhenAcceptInvitation.accept_invitation_complete_now and click_button == self.I_G_ACCEPT:
+        # 如果接受邀请则立即执行悬赏任务
+        if click_button == self.I_G_ACCEPT:
             self.set_next_run(task='WantedQuests', target=datetime.now())
         return True
 

--- a/tasks/base_task.py
+++ b/tasks/base_task.py
@@ -25,7 +25,7 @@ from module.config.config import Config
 from module.config.utils import get_server_next_update, nearest_future, dict_to_kv, parse_tomorrow_server
 from module.device.device import Device
 from tasks.GlobalGame.assets import GlobalGameAssets
-from tasks.GlobalGame.config_emergency import FriendInvitation, WhenNetworkAbnormal, WhenNetworkError
+from tasks.GlobalGame.config_emergency import FriendInvitation, WhenAcceptInvitation, WhenNetworkAbnormal, WhenNetworkError
 from tasks.Component.Costume.costume_base import CostumeBase
 
 from module.exception import GameStuckError, ScriptError
@@ -114,6 +114,8 @@ class BaseTask(GlobalGameAssets, CostumeBase):
                 continue
         # 有的时候长战斗 点击后会取消战斗状态
         self.device.detect_record = detect_record
+        if WhenAcceptInvitation.accept_invitation_complete_now and click_button == self.I_G_ACCEPT:
+            self.set_next_run(task='WantedQuests', target=datetime.now())
         return True
 
     def screenshot(self):


### PR DESCRIPTION
目前有个小问题，没有加入判断是否成功接取，我不知道该怎么写。目前思路是点击接受后 2 秒内重复截图若干次，如果有一次识别到“任务已被其他人接受”字样即跳过执行，都没有识别到则正常执行悬赏。

顺便一提，如果接的悬赏多的话，进探索界面可以看到左边一列，上面的会被对方没有完成的卡住，要往下划一下才能看到。