### PR TITLE
清理御魂时关闭御魂过多的提醒

### DIFF
--- a/tasks/SoulsTidy/assets.py
+++ b/tasks/SoulsTidy/assets.py
@@ -64,5 +64,7 @@ class SoulsTidyAssets:
 	O_ST_SORT_TYPE = RuleOcr(roi=(414,118,64,43), area=(414,118,64,43), mode="Single", method="Default", keyword="类型", name="st_sort_type")
 	# 位置 
 	O_ST_SORT_LOCATION = RuleOcr(roi=(415,119,61,39), area=(415,119,61,39), mode="Single", method="Default", keyword="位置", name="st_sort_location")
+	# Ocr-description 
+	O_ST_OVERFLOW = RuleOcr(roi=(686,397,109,48), area=(686,397,109,48), mode="Single", method="Default", keyword="知道了", name="st_overflow")
 
 

--- a/tasks/SoulsTidy/script_task.py
+++ b/tasks/SoulsTidy/script_task.py
@@ -43,6 +43,8 @@ class ScriptTask(GameUi, SoulsTidyAssets):
                 continue
             if self.click(self.C_ST_DETAIL, interval=1.5):
                 continue
+        # 御魂超过上限的提示
+        self.ocr_appear_click(self.O_ST_OVERFLOW)
         logger.info('Enter souls page')
 
     def back_records(self):

--- a/tasks/SoulsTidy/simple/ocr.json
+++ b/tasks/SoulsTidy/simple/ocr.json
@@ -61,5 +61,14 @@
     "method": "Default",
     "keyword": "位置",
     "description": "位置"
+  },
+  {
+    "itemName": "st_overflow",
+    "roiFront": "686,397,109,48",
+    "roiBack": "686,397,109,48",
+    "mode": "Single",
+    "method": "Default",
+    "keyword": "知道了",
+    "description": "Ocr-description"
   }
 ]


### PR DESCRIPTION
御魂过多时会弹出一个提示框，原代码中并没有对此进行处理，会导致脚本卡住。