### PR TITLE
修改逢魔之时的御魂配置为ocr配置

### DIFF
--- a/tasks/DemonEncounter/config.py
+++ b/tasks/DemonEncounter/config.py
@@ -15,22 +15,22 @@ from tasks.Utils.config_enum import ShikigamiClass
 class DemonConfig(BaseModel):
     enable: bool = Field(default=False)
     # 周一
-    demon_kiryou_utahime: str = Field(default="-1,-1", description="鬼灵歌姬御魂1")
+    demon_kiryou_utahime: str = Field(default="group,team", description="鬼灵歌姬御魂1")
     demon_kiryou_utahime_supplementary: str = Field(
-        default="-1,-1", description="鬼灵歌姬御魂补充"
+        default="group,team", description="鬼灵歌姬御魂补充"
     )
     # 周二
-    demon_shinkirou: str = Field(default="-1,-1", description="蜃气楼御魂")
+    demon_shinkirou: str = Field(default="group,team", description="蜃气楼御魂")
     # 周三 土蜘蛛
-    demon_tsuchigumo: str = Field(default="-1,-1", description="土蜘蛛御魂")
+    demon_tsuchigumo: str = Field(default="group,team", description="土蜘蛛御魂")
     # 周四 荒骷髅
-    demon_gashadokuro: str = Field(default="-1,-1", description="荒骷髅御魂")
+    demon_gashadokuro: str = Field(default="group,team", description="荒骷髅御魂")
     # 周五 地震鲇
-    demon_namazu: str = Field(default="-1,-1", description="地震鲇御魂")
+    demon_namazu: str = Field(default="group,team", description="地震鲇御魂")
     # 周六 胧车
-    demon_oboroguruma: str = Field(default="-1,-1", description="胧车御魂")
+    demon_oboroguruma: str = Field(default="group,team", description="胧车御魂")
     # 周日 夜荒魂
-    demon_nightly_aramitama: str = Field(default="-1,-1", description="夜荒魂御魂")
+    demon_nightly_aramitama: str = Field(default="group,team", description="夜荒魂御魂")
 
 
 class UtilizeScheduler(Scheduler):

--- a/tasks/DemonEncounter/config.py
+++ b/tasks/DemonEncounter/config.py
@@ -13,7 +13,10 @@ from tasks.Utils.config_enum import ShikigamiClass
 
 # 不同封魔boss的御魂配置
 class DemonConfig(BaseModel):
-    enable: bool = Field(default=False)
+    enable: bool = Field(
+        default=False,
+        description="通过预设名称来匹配御魂分组\n例如=> 逢魔之时,歌(中间的是英文逗号)",
+    )
     # 周一
     demon_kiryou_utahime: str = Field(default="group,team", description="鬼灵歌姬御魂1")
     demon_kiryou_utahime_supplementary: str = Field(

--- a/tasks/DemonEncounter/script_task.py
+++ b/tasks/DemonEncounter/script_task.py
@@ -54,21 +54,28 @@ class ScriptTask(GameUi, GeneralBattle, DemonEncounterAssets, SwitchSoul):
         # 判断今天是周几
         today = datetime.now().weekday()
         soul_config = self.config.demon_encounter.demon_soul_config
+        group, team = None, None
         if today == 0:
-            self.run_switch_soul(soul_config.demon_kiryou_utahime)
-            self.run_switch_soul(soul_config.demon_kiryou_utahime_supplementary)
+            # 获取group,team
+            group, team = soul_config.demon_kiryou_utahime.split(",")
         elif today == 1:
-            self.run_switch_soul(soul_config.demon_shinkirou)
+            group, team = soul_config.demon_kiryou_utahime.split(",")
         elif today == 2:
-            self.run_switch_soul(soul_config.demon_tsuchigumo)
+            group, team = soul_config.demon_tsuchigumo.split(",")
         elif today == 3:
-            self.run_switch_soul(soul_config.demon_gashadokuro)
+            group, team = soul_config.demon_gashadokuro.split(",")
         elif today == 4:
-            self.run_switch_soul(soul_config.demon_namazu)
+            group, team = soul_config.demon_namazu.split(",")
         elif today == 5:
-            self.run_switch_soul(soul_config.demon_oboroguruma)
+            group, team = soul_config.demon_oboroguruma.split(",")
         elif today == 6:
-            self.run_switch_soul(soul_config.demon_nightly_aramitama)
+            group, team = soul_config.demon_nightly_aramitama.split(",")
+        if group and team:
+            self.run_switch_soul_by_name(group, team)
+        if today == 0:
+            # 获取group,team
+            group, team = soul_config.demon_kiryou_utahime_supplementary.split(",")
+            self.run_switch_soul_by_name(group, team)
 
     def execute_boss(self):
         """

--- a/tasks/HeroTest/script_task.py
+++ b/tasks/HeroTest/script_task.py
@@ -191,11 +191,11 @@ class ScriptTask(GameUi, BaseActivity, HeroTestAssets):
                         break
                     if self.appear_then_click(self.I_BCMJ_SKILL_ADD2, interval=1):
                         break
+                    if self.appear_then_click(self.I_BCMJ_BLESS, interval=1):
+                        break
                     if self.appear_then_click(
                         self.I_BCMJ_PROPERTY_ADD_CRITICAL, interval=1
                     ):
-                        break
-                    if self.appear_then_click(self.I_BCMJ_BLESS, interval=1):
                         break
                     if self.appear_then_click(
                         self.I_BCMJ__DEFALUT_ATTRIBUTE, interval=1


### PR DESCRIPTION
之前提交的pr是用数字选择群组和队伍的，我发现框架不能选择超过7和4的群组和队伍，于是改成了用ocr识别群组名称和队伍名称来切换御魂