### PR TITLE
修复对弈时间

### DIFF
--- a/tasks/FrogBoss/script_task.py
+++ b/tasks/FrogBoss/script_task.py
@@ -81,8 +81,7 @@ class ScriptTask(RightActivity, FrogBossAssets, GeneralBattleAssets):
         elif 20 <= time_now.hour < 22:
             time_set = time_set.replace(hour=0) + TimeDelta(days=1)
         elif 22 <= time_now.hour < 24:
-            day = time_now.day + 1
-            time_set = time_set.replace(day=day, hour=12)
+            time_set = time_set.replace(hour=12) + TimeDelta(days=1)
         else:
             time_set = time_set.replace(hour=12)
 


### PR DESCRIPTION
这可能导致在月底（比如 31 号）时出现无效的日期（比如将 31 号修改为 32 号），避免出现跨月错误。