### PR TITLE
自定义下次运行时间方法&狩猎战自定义时间

### DIFF
--- a/tasks/AbyssShadows/script_task.py
+++ b/tasks/AbyssShadows/script_task.py
@@ -159,23 +159,18 @@ class ScriptTask(GeneralBattle, GameUi, SwitchSoul, AbyssShadowsAssets):
 
         # 设置下次运行时间
         if success:
-            custom_time = None
             if today == 4:
                 # 周五推迟到周六
                 logger.info(f"The next abyss shadows day is Saturday")
-                custom_time = cfg.abyss_shadows_time.custom_run_time_saturday
-                target_time = (datetime.now() + timedelta(days=1)).replace(hour=custom_time.hour, minute=custom_time.minute, second=custom_time.second)
+                self.custom_next_run(task='AbyssShadows', custom_time=cfg.abyss_shadows_time.custom_run_time_saturday, time_delta=1)
             elif today == 5:
                 # 周六推迟到周日
                 logger.info(f"The next abyss shadows day is Sunday")
-                custom_time = cfg.abyss_shadows_time.custom_run_time_sunday
-                target_time = (datetime.now() + timedelta(days=1)).replace(hour=custom_time.hour, minute=custom_time.minute, second=custom_time.second)
+                self.custom_next_run(task='AbyssShadows', custom_time=cfg.abyss_shadows_time.custom_run_time_sunday, time_delta=1)
             elif today == 6:
                 # 周日推迟到下周五
                 logger.info(f"The next abyss shadows day is Friday")
-                custom_time = cfg.abyss_shadows_time.custom_run_time_friday
-                target_time = (datetime.now() + timedelta(days=5)).replace(hour=custom_time.hour, minute=custom_time.minute, second=custom_time.second)
-            self.set_next_run(task='AbyssShadows', target=target_time)
+                self.custom_next_run(task='AbyssShadows', custom_time=cfg.abyss_shadows_time.custom_run_time_friday, time_delta=5)
         else:
             self.set_next_run(task='AbyssShadows', finish=True, server=True, success=False)
         raise TaskEnd

--- a/tasks/Hunt/config.py
+++ b/tasks/Hunt/config.py
@@ -5,7 +5,12 @@ from datetime import timedelta
 from pydantic import BaseModel, Field
 
 from tasks.Component.config_scheduler import Scheduler
-from tasks.Component.config_base import ConfigBase
+from tasks.Component.config_base import ConfigBase, Time
+
+class HuntTime(ConfigBase):
+    # 自定义运行时间
+    kirin_time: Time = Field(default=Time(hour=19, minute=0, second=0))
+    netherworld_time: Time = Field(default=Time(hour=19, minute=0, second=0))
 
 class HuntConfig(BaseModel):
     kirin_group_team: str = Field(default='-1,-1', description='switch_group_team_help')
@@ -14,4 +19,5 @@ class HuntConfig(BaseModel):
 
 class Hunt(ConfigBase):
     scheduler: Scheduler = Field(default_factory=Scheduler)
+    hunt_time: HuntTime = Field(default_factory=HuntTime)
     hunt_config: HuntConfig = Field(default_factory=HuntConfig)

--- a/tasks/base_task.py
+++ b/tasks/base_task.py
@@ -27,6 +27,7 @@ from module.device.device import Device
 from tasks.GlobalGame.assets import GlobalGameAssets
 from tasks.GlobalGame.config_emergency import FriendInvitation, WhenNetworkAbnormal, WhenNetworkError
 from tasks.Component.Costume.costume_base import CostumeBase
+from tasks.Component.config_base import ConfigBase, Time
 
 from module.exception import GameStuckError, ScriptError
 
@@ -510,6 +511,16 @@ class BaseTask(GlobalGameAssets, CostumeBase):
             start_time = self.start_time
         self.config.task_delay(task, start_time=start_time, success=success, server=server, target=target)
 
+    def custom_next_run(self, task: str, custom_time: Time = None, time_delta: float = 1) -> None:
+        """
+        设置下次自定义运行时间
+        :param task: 任务名称，大驼峰的
+        :param custom_time: 可以自定义的下次运行时间
+        :param time_delta: 下次运行日期为几天后，默认为第二天
+        :return:
+        """
+        target_time = (datetime.now() + timedelta(days=time_delta)).replace(hour=custom_time.hour, minute=custom_time.minute, second=custom_time.second)
+        self.set_next_run(task, target=target_time)
     #  ---------------------------------------------------------------------------------------------------------------
     #
     #  ---------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
~~如题，先不要合并，等我把之前的狭间也改一改~~
已完成，加入 custom_next_run 方法可供未来其他任务调用。狭间、狩猎战的时间每天都不一样，宴会、首领退治也是只有指定的日期才开启，未来可使用此方法精确运行时间。
注意：使用时切勿使用强制执行时间，后者优先级更高。需要将时间调整至默认 9:00:00。