### PR TITLE
寮突击破后自定义时间

### DIFF
--- a/tasks/RyouToppa/config.py
+++ b/tasks/RyouToppa/config.py
@@ -12,6 +12,8 @@ class RaidConfig(BaseModel):
     limit_time: Time = Field(default=Time(minute=30), description='limit_time_help')
     # 限制次数
     limit_count: int = Field(default=50, description='limit_count_help')
+    # 攻破完成后指定下次运行时间
+    next_ryoutoppa_time: Time = Field(default=Time(hour=7, minute=0, second=0))
     # 是否跳过难度较高的结界，失败后不再攻打该结界
     skip_difficult: bool = Field(default=True, description='skip_difficult_help')
     # 寮管理开启寮突破

--- a/tasks/RyouToppa/script_task.py
+++ b/tasks/RyouToppa/script_task.py
@@ -2,7 +2,7 @@
 # @author runhey
 # github https://github.com/runhey
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, time
 import random
 
 from tasks.Component.SwitchSoul.switch_soul import SwitchSoul

--- a/tasks/RyouToppa/script_task.py
+++ b/tasks/RyouToppa/script_task.py
@@ -144,7 +144,8 @@ class ScriptTask(GeneralBattle, GameUi, SwitchSoul, RyouToppaAssets):
 
         # 100% 攻破, 第二天再执行
         if ryou_toppa_success_penetration:
-            self.set_next_run(task='RyouToppa', finish=True, success=True)
+            logger.info('RyouToppa is 100%')
+            self.plan_tomorrow_ryoutoppa()
             raise TaskEnd
         if self.config.ryou_toppa.general_battle_config.lock_team_enable:
             logger.info("Lock team.")
@@ -189,6 +190,16 @@ class ScriptTask(GeneralBattle, GameUi, SwitchSoul, RyouToppaAssets):
             self.set_next_run(task='RyouToppa', finish=True, server=True, success=False)
         raise TaskEnd
 
+    def plan_tomorrow_ryoutoppa(self):
+        # 安排下次寮突破，便于复用
+        now = datetime.now()
+        # 如果时间在00:00-5:00之间则设定时间为当天的自定义时间
+        if now.time() < time(5, 0):
+            self.custom_next_run(task='RyouToppa', custom_time=self.config.ryou_toppa.raid_config.next_ryoutoppa_time, time_delta=0)
+        # 如果时间在05:00-23:59之间则设定时间为明天的自定义时间
+        else:
+            self.custom_next_run(task='RyouToppa', custom_time=self.config.ryou_toppa.raid_config.next_ryoutoppa_time, time_delta=1)
+
     def start_ryou_toppa(self):
         """
         开启寮突破
@@ -223,8 +234,8 @@ class ScriptTask(GeneralBattle, GameUi, SwitchSoul, RyouToppaAssets):
         如果没有票了，那么就返回False
         :return:
         """
-        # 21点后无限进攻机会
-        if datetime.now().hour >= 21:
+        # 21点后、次日5点前无限进攻机会
+        if datetime.now().hour >= 21 or datetime.now().hour <= 5:
             return True
         self.wait_until_appear(self.I_TOPPA_RECORD)
         self.screenshot()
@@ -245,7 +256,8 @@ class ScriptTask(GeneralBattle, GameUi, SwitchSoul, RyouToppaAssets):
         # 如果该区域已经被攻破则退出
         # Ps: 这时候能打过的都打过了，没有能攻打的结界了, 代表任务已经完成，set_next_run time=1d
         if self.appear(f3, threshold=0.8) or self.appear(f4, threshold=0.8):
-            self.set_next_run(task='RyouToppa', finish=True, success=True)
+            logger.info('RyouToppa has tried to attack')
+            self.plan_tomorrow_ryoutoppa()
             raise TaskEnd
         # 如果该区域攻略失败返回 False
         if self.appear(f1, threshold=0.8) or self.appear(f2, threshold=0.8):


### PR DESCRIPTION
顺便补上了 https://github.com/runhey/OnmyojiAutoScript/issues/233

```
INFO           | 00:56:39.209 | Page switch: page_main -> page_exploration            
INFO           | 00:56:39.221 | Click ( 683,  180) @ PAGE_MAIN_GOTO_EXPLORATION       
INFO           | 00:56:40.431 | Page switch: page_exploration -> page_realm_raid      
INFO           | 00:56:40.432 | Click ( 259,  650) @ PAGE_EXPLORATION_GOTO_REALM_RAID 
INFO           | 00:56:41.032 | Page switch: page_realm_raid -> page_kekkai_toppa     
INFO           | 00:56:41.035 | Click (1264,  455) @ RES_RYOU_TOPPA                   
INFO           | 00:56:41.311 | Page arrive: page_kekkai_toppa                        
INFO           | 00:56:41.615 | [ryou_toppa_start_flag] True                          
INFO           | 00:56:41.617 | [ryou_toppa_success_penetration] True                 
INFO           | 00:56:41.618 | RyouToppa is 100%                                     
INFO           | 00:56:41.625 | Delay task `ryou_toppa` to 2024-11-20 06:55:24        
         (server_update=True, target=datetime.datetime(2024, 11, 20, 7, 0, 0,   
         619158))                                                               
INFO           | 00:56:41.633 | [ryou_toppa.scheduler.next_run] 2024-11-20 06:55:24   
INFO           | 00:56:41.634 | Scheduler: End task `RyouToppa`                       
INFO           | 00:56:41.644 | No task pending                                       
```