### PR TITLE
强制时间增加日期间隔

### DIFF
--- a/module/config/config.py
+++ b/module/config/config.py
@@ -351,7 +351,7 @@ class Config(ConfigState, ConfigManual, ConfigWatcher, ConfigMenu):
             if scheduler.server_update == time(hour=9):
                 next_run += timedelta(seconds=random_float)
             else:
-                next_run = parse_tomorrow_server(scheduler.server_update, random_float)
+                next_run = parse_tomorrow_server(scheduler.server_update, scheduler.delay_date, random_float)
 
         # 将这些连接起来，方便日志输出
         kv = dict_to_kv(

--- a/module/config/utils.py
+++ b/module/config/utils.py
@@ -244,7 +244,7 @@ def dict_to_kv(dictionary, allow_none=True):
     return ', '.join([f'{k}={repr(v)}' for k, v in dictionary.items() if allow_none or v is not None])
 
 
-def parse_tomorrow_server(server_update: time, float_seconds: int = 0) -> datetime:
+def parse_tomorrow_server(server_update: time, delay_date: int = 1, float_seconds: int = 0) -> datetime:
     """
     获取明天的日期，给这个日期加上server_update的时间，返回datetime
     :param server_update:
@@ -254,7 +254,7 @@ def parse_tomorrow_server(server_update: time, float_seconds: int = 0) -> dateti
     if isinstance(server_update, str):
         server_update = time.fromisoformat(server_update)
     now = datetime.now()
-    tomorrow = now + timedelta(days=1)
+    tomorrow = now + timedelta(days=delay_date)
     next_run = datetime.combine(tomorrow, server_update)
     
     # 应用浮动时间

--- a/tasks/Component/config_scheduler.py
+++ b/tasks/Component/config_scheduler.py
@@ -16,6 +16,7 @@ class Scheduler(ConfigBase):
     success_interval: TimeDelta = Field(default=TimeDelta(days=1), description='success_interval_help')
     failure_interval: TimeDelta = Field(default=TimeDelta(days=1), description='failure_interval_help')
     server_update: Time = Field(default=Time(hour=9, minute=0, second=0), description='server_update_help')
+    delay_date: int = Field(default=1, description='delay_date_help', ge=1, le=31)
     float_time: Time = Field(default=Time(hour=0, minute=0, second=0), description='float_time_help')
 
     @validator('next_run', pre=True, always=True)


### PR DESCRIPTION
比如魂海可以双开在每周五的固定时间打（最主要的用法）、秘闻可以每周一九点开门就打（混排名奖励）、六道之门、商店等等
也可以每两天、三天等运行一次，目前为防乱输限制最高 31 天