### PR TITLE
定时重启领取体力

### DIFF
--- a/tasks/Restart/script_task.py
+++ b/tasks/Restart/script_task.py
@@ -6,7 +6,8 @@
 from tasks.Restart.config_scheduler import Scheduler
 from tasks.Restart.login import LoginHandler
 from tasks.Restart.assets import RestartAssets
-from tasks.base_task import BaseTask
+from tasks.base_task import BaseTask, Time
+from datetime import datetime, time
 
 from module.logger import logger
 from module.exception import TaskEnd, RequestHumanTakeover
@@ -43,6 +44,18 @@ class ScriptTask(LoginHandler):
 
         # self.config.task_delay(server_update=True)
         self.set_next_run(task='Restart', success=True, finish=True, server=True)
+        # 如果启用了定时领体力（每天 12-14、20-22 时内各有 20 体力）
+        if self.config.restart.harvest_config.enable_ap:
+            now = datetime.now()
+            # 如果时间在00:00-12:00之间则设定时间为当日 12 时
+            if now.time() < time(12, 0):
+                self.custom_next_run(task='Restart', custom_time=Time(hour=12, minute=0, second=0), time_delta=0)
+            # 如果时间在12:00-20:00之间则设定时间为当日 20 时
+            elif now.time() >= time(12, 0) and now.time() < time(20, 0):
+                self.custom_next_run(task='Restart', custom_time=Time(hour=20, minute=0, second=0), time_delta=0)
+            # 如果时间在20:00-23:59之间则设定时间为次日 12 时
+            else:
+                self.custom_next_run(task='Restart', custom_time=Time(hour=12, minute=0, second=0), time_delta=1)
 
 
 

--- a/tasks/Restart/script_task.py
+++ b/tasks/Restart/script_task.py
@@ -49,13 +49,13 @@ class ScriptTask(LoginHandler):
             now = datetime.now()
             # 如果时间在00:00-12:00之间则设定时间为当日 12 时
             if now.time() < time(12, 0):
-                self.custom_next_run(task='Restart', custom_time=Time(hour=12, minute=0, second=0), time_delta=0)
+                self.custom_next_run(task='Restart', custom_time=Time(12, 0), time_delta=0)
             # 如果时间在12:00-20:00之间则设定时间为当日 20 时
             elif now.time() >= time(12, 0) and now.time() < time(20, 0):
-                self.custom_next_run(task='Restart', custom_time=Time(hour=20, minute=0, second=0), time_delta=0)
+                self.custom_next_run(task='Restart', custom_time=Time(20, 0), time_delta=0)
             # 如果时间在20:00-23:59之间则设定时间为次日 12 时
             else:
-                self.custom_next_run(task='Restart', custom_time=Time(hour=12, minute=0, second=0), time_delta=1)
+                self.custom_next_run(task='Restart', custom_time=Time(12, 0), time_delta=1)
 
 
 


### PR DESCRIPTION
每天 12-14、20-22 时内各有 20 体力，如果勾选了重启中的“体力”选项将会定时重启领取。
另外，首次运行重启任务时将会自动跳过，本人使用中为了防止跳过一天的领取体力，将重启任务的执行任务成功后延迟时间设置为 10 分钟（一小时也可），可以在不久后再次运行，仅供参考。