### PR TITLE
修复寄养无限卡住的问题

### DIFF
--- a/tasks/KekkaiUtilize/script_task.py
+++ b/tasks/KekkaiUtilize/script_task.py
@@ -8,7 +8,7 @@ from datetime import timedelta, datetime
 from module.base.timer import Timer
 from module.atom.image_grid import ImageGrid
 from module.logger import logger
-from module.exception import TaskEnd
+from module.exception import TaskEnd,GameStuckError
 
 from tasks.GameUi.game_ui import GameUi
 from tasks.Utils.config_enum import ShikigamiClass
@@ -461,7 +461,13 @@ class ScriptTask(GameUi, ReplaceShikigami, KekkaiUtilizeAssets):
             # 可能是滑动的时候出错
             logger.warning('The best reason is that the swipe is wrong')
             return False
+        TIMEOUT_SEC = 120          # 超时时长（秒）
+        start_time = time.time()   # 记录起始时间
         while 1:
+            # ——1. 先做超时检查——
+            if time.time() - start_time > TIMEOUT_SEC:
+                logger.error('寄养等待超过 2 分钟，自动退出')
+                raise GameStuckError('寄养超时（>120 s）')
             self.screenshot()
             if self.appear(self.I_CHECK_FRIEND_REALM_1):
                 self.wait_until_stable(self.I_CHECK_FRIEND_REALM_1)


### PR DESCRIPTION
在进入寄养的结界后，极小概率另一个人在你进入结界的瞬间寄养了式神
此时脚本会不停的尝试寄养但是会提示寄养失败，永久卡住且无报错

增加一个检测超时的功能兜底