### PR TITLE
修复登录时无限卡住的问题

### DIFF
--- a/tasks/Restart/login.py
+++ b/tasks/Restart/login.py
@@ -7,7 +7,7 @@ from module.exception import RequestHumanTakeover, GameTooManyClickError, GameSt
 from module.logger import logger
 from tasks.Restart.assets import RestartAssets
 from tasks.base_task import BaseTask
-
+import time
 
 class LoginHandler(BaseTask, RestartAssets):
     character: str
@@ -111,12 +111,18 @@ class LoginHandler(BaseTask, RestartAssets):
             if self.appear(self.I_CREATE_ACCOUNT):
                 logger.warning('Appear create account')
                 raise GameStuckError('Appear create account')
+
+            # 点击“进入游戏”速度过快会进入区服设置，同时需在检测I_LOGIN_8之前检测，因为新服图标会让I_LOGIN_8向右偏移导致永远无法检测成功
+            # 同时修复了点击位置（之前是点击I_CHARACTARS而不是左边的区域）
+            if self.appear(self.I_CHARACTARS, interval=1):
+                logger.info('误入区服设置')
+                # https://github.com/runhey/OnmyojiAutoScript/issues/585
+                self.device.click(x=106, y=535)
+                
             # 点击’进入游戏‘
             if not self.appear(self.I_LOGIN_8):
                 continue
-            if self.appear(self.I_CHARACTARS, interval=1):
-                # https://github.com/runhey/OnmyojiAutoScript/issues/585
-                self.device.click(x=246, y=535)
+            
             # 登录体验服时，点击“进入游戏”速度过快，可能会出现体验服的弹窗
             if self.appear(self.I_EARLY_SERVER):
                 if self.appear_then_click(self.I_EARLY_SERVER_CANCEL):
@@ -254,7 +260,8 @@ class LoginHandler(BaseTask, RestartAssets):
                     self.wait_until_appear(self.I_HARVEST_MAIL_CONFIRM, wait_time=1)
                     timer_harvest.reset()
                     continue
-                if self.appear(self.I_HARVEST_MAIL_OPEN, threshold=0.9):
+                #threshold如果是0.9，可能会导致有邮件但无法识别永久卡住
+                if self.appear(self.I_HARVEST_MAIL_OPEN, threshold=0.8):
                     self.click(self.I_HARVEST_MAIL_OPEN, interval=0.8)
                     timer_harvest.reset()
                     continue


### PR DESCRIPTION
首先是由于网络有时候会卡，导致的进入游戏打开区服的问题，之前的脚本的点击位置会点击到“桂之x"服务器而不是左边让他关闭。

其次有新区集结的图标时会挤占年龄8+的图片导致识别不到登录界面，所以必须提高到识别8+前识别是否误入区服设置。这条建议必须合

第二个是邮件的设置，0.9下调到0.8防止有邮件的情况下识别不到无限循环打开邮箱，这条可以改也可以不改，或者有人也可以更新图片，我懒。