### PR TITLE
修复探索无限滑动不报错的问题

### DIFF
--- a/tasks/Exploration/base.py
+++ b/tasks/Exploration/base.py
@@ -22,7 +22,7 @@ from tasks.Utils.config_enum import ShikigamiClass
 
 from module.logger import logger
 from module.base.timer import Timer
-from module.exception import RequestHumanTakeover, TaskEnd
+from module.exception import RequestHumanTakeover, TaskEnd, GameStuckError
 from module.atom.image_grid import ImageGrid
 from module.atom.animate import RuleAnimate
 from module.base.utils import load_image
@@ -151,8 +151,14 @@ class BaseExploration(GameUi, GeneralBattle, GeneralRoom, GeneralInvite, Replace
             self.device.click_record_clear()
             self.swipe(self.S_SWIPE_LEVEL_UP)
             swipeCount += 1
+            debug_info = f"Swiped {swipeCount} times, current exploration level: {text1}"
+            logger.info(debug_info)
             if swipeCount >= 25:
+                raise GameStuckError(
+                    f"Swiped too many times ({swipeCount}), seems stuck in exploration level selection"
+                )
                 return False
+            time.sleep(1)
 
         # 选中对应章节
         while 1:

--- a/tasks/Hyakkiyakou/utils/exp_test.py
+++ b/tasks/Hyakkiyakou/utils/exp_test.py
@@ -23,7 +23,7 @@ from tasks.Exploration.config import ExplorationLevel
 
 from utils import usage_time
 from fast_device import FastDevice
-
+from module.exception import GameStuckError
 
 class Step:
     def __init__(self,
@@ -342,6 +342,9 @@ class ExpTest(RightActivity, FastDevice, RestartAssets, ExplorationAssets):
             self.swipe(self.S_SWIPE_LEVEL_UP)
             swipeCount += 1
             if swipeCount >= 25:
+                raise GameStuckError(
+                    f"Swiped too many times ({swipeCount}), seems stuck in exploration level selection"
+                )
                 return False
         self.config.model.script.device.control_method = ControlMethod.WINDOW_MESSAGE
 


### PR DESCRIPTION
探索有时候滑动但是没识别到会继续滑动到第一章，原代吗swipe超过25次后没有提报错会导致无限滑动无报错，我修改了此处让其滑动超过25次报一个普通的GameStuckError然后重启。
同时在滑动一次后等1s再滑动，显著降低出现这种情况的发生概率。

已测试超过两周没有问题，且这个bug触发概率很高，建议合上。