### PR TITLE
fix(device):修复MuMu5.0无法自动获取窗体标题的问题

### DIFF
--- a/module/device/handle.py
+++ b/module/device/handle.py
@@ -257,6 +257,11 @@ class Handle:
         # 事实上 我们只需要最后一个 'MuMu模拟器12'，其他的不重要
         if 'MuMu模拟器12' in emu_list and 'MuMuPlayer' in emu_list:
             emulator_title = 'MuMu模拟器12'
+        
+        # MuMu5.0更新，窗体标题改动: 'MuMu模拟器','MuMuNxDevice','MuMu安卓设备'
+        # 如果没有匹配上旧版本，尝试匹配MuMu5.0窗口名                                                                  
+        if emulator_title == '' and 'MuMu安卓设备' in emu_list:
+            emulator_title = 'MuMu安卓设备'
 
         if len(emu_list) > 1 and emulator_title == '':
             logger.warning(f'Find more than one emulator handle, oas will use the first one {emu_list[0]}')


### PR DESCRIPTION
更新MuMu5.0后，窗体标题会变为MuMu安卓设备，如果标题设置为'auto'会无法自动获取。
修复方案: 在自动获取窗体标题时，添加对新标题的判断。
关联ISSUE：https://github.com/runhey/OnmyojiAutoScript/issues/1044