### PR TITLE
fix: switch soul

### DIFF
--- a/tasks/Component/SwitchSoul/switch_soul.py
+++ b/tasks/Component/SwitchSoul/switch_soul.py
@@ -136,7 +136,8 @@ class SwitchSoul(BaseTask, SwitchSoulAssets):
                 continue
             if not self.appear_then_click(target_team, interval=3):
                 logger.warning(f'Click team {team} failed in group {group}')
-
+        # 兜底若还出现确认按钮则点击
+        self.ui_click_until_disappear(self.I_SOU_SWITCH_SURE)
         logger.info(f'Switch soul_one group {group} team {team}')
 
     def switch_souls(self, target: tuple or list[tuple]) -> None:


### PR DESCRIPTION
[issues1081](https://github.com/runhey/OnmyojiAutoScript/issues/1081)
bug复现:（御魂冲突会出现,其他情况未知）
第一次循环：切换队伍->弹出确认按钮
第二次循环：点击确认按钮，跳过切换队伍
第三次循环：切换队伍->弹出确认按钮
结束

导致页面还存在确认按钮弹窗,之后跳转页面会识别左上角返回而不点击确认导致卡住
添加兜底:切换完御魂若还出现确认按钮则点掉