### PR TITLE
feat ryoutoppa

### DIFF
--- a/module/device/device.py
+++ b/module/device/device.py
@@ -29,7 +29,7 @@ class Device(Platform, Screenshot, Control, AppControl):
     click_record = deque(maxlen=15)
     stuck_timer = Timer(60, count=60).start()
     stuck_timer_long = Timer(300, count=300).start()
-    stuck_long_wait_list = ['BATTLE_STATUS_S', 'PAUSE', 'LOGIN_CHECK']
+    stuck_long_wait_list = ['BATTLE_STATUS_S', 'PAUSE', 'LOGIN_CHECK', 'PREPARE_BEFORE_BATTLE']
 
     def __init__(self, *args, **kwargs):
         for trial in range(4):

--- a/tasks/RyouToppa/script_task.py
+++ b/tasks/RyouToppa/script_task.py
@@ -159,6 +159,8 @@ class ScriptTask(GeneralBattle, GameUi, SwitchSoul, RyouToppaAssets):
         area_index = 0
         success = True
         while 1:
+            # 设置长任务标志,用来寻找寮突可进攻的目标
+            self.device.stuck_record_add('PREPARE_BEFORE_BATTLE')
             if not self.has_ticket():
                 logger.info("We have no chance to attack. Try again after 1 hour.")
                 success = False


### PR DESCRIPTION
延长寮突寻找目标的时间,修复即使还有很多可攻击的目标但是因为前面失败次数过多导致寻找时间过长,然后超时的问题