### PR TITLE
fix(Updater): change to show remote branch

### DIFF
--- a/module/server/updater.py
+++ b/module/server/updater.py
@@ -63,7 +63,7 @@ class Updater(DeployConfig, GitManager, PipManager):
             return logs
 
     def current_branch(self) -> str:
-        return self.filepath('Branch')
+        return self.Branch
 
     def current_commit(self) -> str:
         return self.get_commit()


### PR DESCRIPTION
分支显示修改为拉取远程仓库代码的分支，本地仓库不开发不进行分支切换的话永远都是master没必要显示