### PR TITLE
Dokan

### DIFF
--- a/tasks/Dokan/script_task.py
+++ b/tasks/Dokan/script_task.py
@@ -384,6 +384,7 @@ class ScriptTask(ExtendGreenMark, GameUi, SwitchSoul, DokanSceneDetector):
             if battle_config.random_click_swipt_enable:
                 logger.info("random swipt ...")
                 self.random_click_swipt()
+                self.device.stuck_record_add('BATTLE_STATUS_S')
 
             # 打完一个小朋友，自动进入下一个小朋友
             if self.appear(self.I_RYOU_DOKAN_IN_FIELD):


### PR DESCRIPTION
修复道馆因开启随机点击或滑动导致的长战斗任务状态失效的问题
[issues/1184](https://github.com/runhey/OnmyojiAutoScript/issues/1184)