### PR TITLE
SwitchSoul

### DIFF
--- a/tasks/Component/SwitchSoul/switch_soul.py
+++ b/tasks/Component/SwitchSoul/switch_soul.py
@@ -246,11 +246,6 @@ class SwitchSoul(BaseTask, SwitchSoulAssets):
         logger.info('Swipe up to find target team')
 
         # 选中分组
-        while 1:
-            self.screenshot()
-            self.O_SS_TEAM_NAME.keyword = teamName
-            if self.ocr_appear_click(self.O_SS_TEAM_NAME):
-                break
         logger.info(f'Select team {teamName}')
         # 切换御魂
         cnt_click: int = 0
@@ -284,7 +279,7 @@ class SwitchSoul(BaseTask, SwitchSoulAssets):
         if not appear:
             return False
 
-        x1, y1, w1, h1 = target.area
+        x1, y1 = target.coord()
         x, y = action.coord()
 
         self.device.click(x=x, y=y1, control_name=target.name)


### PR DESCRIPTION
修复ocr切换队伍御魂时会点击对应队伍名称，导致名称偏移或消失然后切换队伍御魂失败的bug