### PR TITLE
fix(Exploration): add timeout for shikigami addition

### DIFF
--- a/tasks/Exploration/base.py
+++ b/tasks/Exploration/base.py
@@ -228,7 +228,11 @@ class BaseExploration(GameUi, GeneralBattle, GeneralRoom, GeneralInvite, Replace
                 self.swipe(self.S_SWIPE_SHIKI_TO_LEFT)
             else:
                 break
+        operation_timeout = Timer(60)
+        operation_timeout.start()
         while 1:
+            if operation_timeout.reached():
+                raise GameStuckError('Adding shikigami timeout')
             # 候补出战数量识别
             self.screenshot()
             if not self.appear(self.I_E_OPEN_SETTINGS):


### PR DESCRIPTION
为 `tasks/Exploration/base.py` 中的 `add_shiki` 方法引入了超时机制，以防止该方法无限期地处于“滑动+点击”状态。如果添加狗粮式神所需时间超过 60秒，则认为存在问题。

引发此问题的两种机制：
1. 点击到出战式神框，导致候补狗粮添加不了
2. 设置的狗粮不足

ps：只进行了简单测试，不知道60s是否能满足所有情况