### PR TITLE
修复结界突破偶然卡死的问题

### DIFF
--- a/tasks/RealmRaid/script_task.py
+++ b/tasks/RealmRaid/script_task.py
@@ -181,7 +181,7 @@ class ScriptTask(GeneralBattle, GameUi, SwitchSoul, RealmRaidAssets):
                 else:
                     logger.info('No one can attack, break')
                     # 检查是否有“刷新确认”弹窗挡路
-                     if self.appear(self.I_FRESH_ENSURE):
+                    if self.appear(self.I_FRESH_ENSURE):
                         logger.info("Closing obstructing refresh dialog (Click Ensure)...")
                         # 点击“确定”来完成刷新（或者你可以改成点取消）
                         self.appear_then_click(self.I_FRESH_ENSURE, interval=2)


### PR DESCRIPTION
1.解决刷新窗口的弹出，偶然会遮蔽背景红叉按钮，导致死循环(加检测)
2.突破奖励结算页面，脚本以为回到了突破选择对手界面，准备退4，但是依然还在奖励结算页面没点掉导致循环卡死不动(加检测)
[log.txt](https://github.com/user-attachments/files/24694341/log.txt)
[log (1).txt](https://github.com/user-attachments/files/24694340/log.1.txt)
