### PR TITLE
修复探索任务结束时触发宝箱/妖气导致卡死的问题

### DIFF
--- a/tasks/Exploration/base.py
+++ b/tasks/Exploration/base.py
@@ -376,11 +376,17 @@ class BaseExploration(GameUi, GeneralBattle, GeneralRoom, GeneralInvite, Replace
         logger.info('Quit explore')
         boss_timer = Timer(15)
         boss_timer.start()
+        click_yellow_button = 0 #用于保证只点一次左上返回按钮，不要直接触发连点回到主界面
         
         while 1:
             self.screenshot()
             
+            #探索章节标题界面
             if self.appear(self.I_UI_BACK_RED) and self.appear(self.I_E_EXPLORATION_CLICK):
+                break
+            
+            #探索大世界界面
+            if self.appear(self.I_CHECK_EXPLORATION) and not self.appear(self.I_E_SETTINGS_BUTTON):
                 break
   
             # 防止BOSS打完箱子刚落地，脚本就手快点退出了
@@ -398,8 +404,10 @@ class BaseExploration(GameUi, GeneralBattle, GeneralRoom, GeneralInvite, Replace
             if self.appear_then_click(self.I_E_EXIT_CONFIRM, interval=0.8):
                 continue
             
-            if self.appear_then_click(self.I_BACK_YOLLOW, interval=3.5):
-                continue
+            if click_yellow_button == 0:
+                if self.appear_then_click(self.I_BACK_YOLLOW, interval=3.5):
+                    click_yellow_button = 1
+                    continue
             
             if self.appear(self.I_EXPLORATION_TITLE) or self.appear(self.I_CHECK_EXPLORATION):
                 continue


### PR DESCRIPTION
现有的quit_explore函数仅考虑了退出探索回到入口界面的情况。然而，当探索任务结束时，该次探索任务可能触发宝箱/妖气/石距等特殊任务，这会导致此时界面会变为探索大世界界面。 此时quit_explore会超时强制点左上角，从而触发回到主界面-点击头像-卡死的过程。
本pull request修改了这一函数以解决该问题，实测有效。
<img width="696" height="276" alt="屏幕截图 2026-02-08 091043" src="https://github.com/user-attachments/assets/303f79de-3e4e-493a-9cce-dac9cb18f164" />
