### PR TITLE
feat(ocr): OCR Server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,14 +42,12 @@ oas-backend.bat
 .eslintignore
 .eslintrc.js
 .prettierrc.js
-
-
-
-
-
-
-
-
+# ai
+AGENTS.md
+CLAUDE.md
+.codex/
+.claude/
+openspec/
 
 
 # Created by .ignore support plugin (hsz.mobi)
@@ -272,6 +270,5 @@ adb_port.ini
 *.zip
 console.bat
 .vscode/*
-.claude/settings.local.json
 tasks/AutoCheckinBigGod/frida-server-17.6.2-android-x86_64
 oas.bat

--- a/gui.py
+++ b/gui.py
@@ -10,8 +10,10 @@ from module.gui.context.utils import Utils
 from module.gui.register_type.paint_image import PaintImage
 from module.gui.register_type.rule_file import RuleFile
 from module.gui.fluent_app import FluentApp
+from module.ocr.rpc import ensure_ocr_server_started
 
 if __name__ == "__main__":
+    ensure_ocr_server_started()
     # 检查是不是以管理员身份运行，脚本启动的其他进程会继承权限
     # 但是貌似有问题的这个函数
     # check_admin()

--- a/module/ocr/base_ocr.py
+++ b/module/ocr/base_ocr.py
@@ -11,8 +11,9 @@ from enum import Enum
 
 from module.base.decorator import cached_property
 from module.base.utils import area_pad, crop, float2str
-from module.ocr.ppocr import TextSystem
-from module.ocr.models import OCR_MODEL
+from typing import Any
+
+from module.ocr.models import get_ocr_model
 from module.exception import ScriptError
 from module.logger import logger
 
@@ -94,8 +95,8 @@ class BaseCor:
         return f"{self.name}"
 
     @cached_property
-    def model(self) -> TextSystem:
-        return OCR_MODEL.__getattribute__(self.lang)
+    def model(self) -> Any:
+        return get_ocr_model(self.lang)
 
     def pre_process(self, image):
         """

--- a/module/ocr/models.py
+++ b/module/ocr/models.py
@@ -1,5 +1,9 @@
+from typing import Dict
+
 from module.base.decorator import cached_property
 from module.ocr.ppocr import TextSystem
+from module.ocr.rpc import ModelProxy
+from module.server.setting import State
 
 
 class OcrModel:
@@ -10,6 +14,17 @@ class OcrModel:
 
 OCR_MODEL = OcrModel()
 
+_OCR_PROXY_CACHE: Dict[str, ModelProxy] = {}
+
+
+def get_ocr_model(lang: str = "ch"):
+    deploy_config = State.deploy_config
+    if deploy_config.UseOcrServer:
+        address = deploy_config.OcrClientAddress or "127.0.0.1:22268"
+        if address not in _OCR_PROXY_CACHE:
+            _OCR_PROXY_CACHE[address] = ModelProxy(address)
+        return _OCR_PROXY_CACHE[address]
+    return getattr(OCR_MODEL, lang)
 
 
 if __name__ == "__main__":

--- a/module/ocr/rpc.py
+++ b/module/ocr/rpc.py
@@ -1,0 +1,178 @@
+# This Python file uses the following encoding: utf-8
+# @author runhey
+# github https://github.com/runhey
+import multiprocessing
+import pickle
+import socket
+import time
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import zerorpc
+
+from module.exception import ScriptError
+from module.logger import logger
+from module.ocr.ppocr import TextSystem
+
+_OCR_SERVER_PROCESS: Optional[multiprocessing.Process] = None
+
+
+def _normalize_address(address: str) -> str:
+    if address.startswith("tcp://"):
+        return address
+    return f"tcp://{address}"
+
+
+def _split_host_port(address: str) -> tuple[str, int]:
+    addr = address.replace("tcp://", "")
+    if ":" not in addr:
+        return addr, 22268
+    host, port = addr.rsplit(":", 1)
+    return host, int(port)
+
+
+def _is_port_in_use(host: str, port: int) -> bool:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        s.settimeout(0.5)
+        s.connect((host, port))
+        s.shutdown(2)
+        return True
+    except Exception:
+        return False
+    finally:
+        s.close()
+
+
+def ensure_ocr_server_started() -> bool:
+    from module.server.setting import State
+
+    deploy_config = State.deploy_config
+    if not deploy_config.StartOcrServer:
+        return False
+
+    if deploy_config.OcrServerPort:
+        port = int(deploy_config.OcrServerPort)
+    else:
+        _, port = _split_host_port(str(deploy_config.OcrClientAddress))
+    host = "0.0.0.0"
+
+    if _is_port_in_use("127.0.0.1", port):
+        logger.info(f"OCR server already running on port {port}")
+        return True
+
+    global _OCR_SERVER_PROCESS
+    if _OCR_SERVER_PROCESS is not None and _OCR_SERVER_PROCESS.is_alive():
+        logger.info("OCR server process already started")
+        return True
+
+    _OCR_SERVER_PROCESS = multiprocessing.Process(
+        target=run_ocr_server,
+        args=(host, port),
+        name="ocr_server",
+        daemon=True,
+    )
+    _OCR_SERVER_PROCESS.start()
+    logger.info(f"Start OCR server on {host}:{port}")
+    for _ in range(50):
+        if _is_port_in_use("127.0.0.1", port):
+            return True
+        time.sleep(0.1)
+    logger.error(f"OCR server is not ready on port {port}")
+    return False
+
+
+def run_ocr_server(host: str, port: int) -> None:
+    server = zerorpc.Server(OcrServer())
+    server.bind(f"tcp://{host}:{port}")
+    server.run()
+
+
+class OcrServer:
+    def __init__(self) -> None:
+        self.model = TextSystem()
+
+    def ping(self) -> bool:
+        return True
+
+    @staticmethod
+    def _rotate_vertical(image: np.ndarray) -> np.ndarray:
+        height, width = image.shape[0:2]
+        if height * 1.0 / width >= 1.5:
+            return np.rot90(image)
+        return image
+
+    def ocr_single_line(self, image_bytes: bytes):
+        image = pickle.loads(image_bytes)
+        result, score = self.model.ocr_single_line(image)
+        return result, float(score)
+
+    def detect_and_ocr(
+        self,
+        image_bytes: bytes,
+        drop_score: float = 0.5,
+        unclip_ratio: Optional[float] = None,
+        box_thresh: Optional[float] = None,
+        vertical: bool = False,
+    ) -> List[Dict[str, Any]]:
+        image = pickle.loads(image_bytes)
+        if not vertical:
+            results = self.model.detect_and_ocr(image, drop_score=drop_score,
+                                                unclip_ratio=unclip_ratio,
+                                                box_thresh=box_thresh)
+            return [
+                {"box": r.box.tolist(), "ocr_text": r.ocr_text, "score": float(r.score)}
+                for r in results
+            ]
+
+        text_recognizer = self.model.text_recognizer
+
+        def vertical_text_recognizer(img_crop_list):
+            img_crop_list = [self._rotate_vertical(i) for i in img_crop_list]
+            return text_recognizer(img_crop_list)
+
+        self.model.text_recognizer = vertical_text_recognizer
+        try:
+            results = self.model.detect_and_ocr(image, drop_score=drop_score,
+                                                unclip_ratio=unclip_ratio,
+                                                box_thresh=box_thresh)
+        finally:
+            self.model.text_recognizer = text_recognizer
+
+        return [
+            {"box": r.box.tolist(), "ocr_text": r.ocr_text, "score": float(r.score)}
+            for r in results
+        ]
+
+
+class ModelProxy:
+    is_proxy = True
+
+    def __init__(self, address: str) -> None:
+        self.address = _normalize_address(address)
+        self.client = zerorpc.Client()
+        try:
+            self.client.connect(self.address)
+            self.client.ping()
+        except Exception as e:
+            raise ScriptError(f"OCR server connection failed: {self.address}") from e
+
+    def ocr_single_line(self, image: np.ndarray):
+        payload = pickle.dumps(image, protocol=4)
+        return self.client.ocr_single_line(payload)
+
+    def detect_and_ocr(
+        self,
+        image: np.ndarray,
+        drop_score: float = 0.5,
+        unclip_ratio: Optional[float] = None,
+        box_thresh: Optional[float] = None,
+        vertical: bool = False,
+    ):
+        payload = pickle.dumps(image, protocol=4)
+        results = self.client.detect_and_ocr(payload, drop_score, unclip_ratio, box_thresh, vertical)
+        from ppocronnx.predict_system import BoxedResult
+        return [
+            BoxedResult(np.array(item["box"]), None, item["ocr_text"], item["score"])
+            for item in results
+        ]

--- a/module/ocr/rpc.py
+++ b/module/ocr/rpc.py
@@ -1,6 +1,7 @@
 # This Python file uses the following encoding: utf-8
 # @author runhey
 # github https://github.com/runhey
+import atexit
 import multiprocessing
 import pickle
 import socket
@@ -80,6 +81,34 @@ def ensure_ocr_server_started() -> bool:
         time.sleep(0.1)
     logger.error(f"OCR server is not ready on port {port}")
     return False
+
+
+def shutdown_ocr_server(timeout: float = 2.0) -> bool:
+    global _OCR_SERVER_PROCESS
+
+    process = _OCR_SERVER_PROCESS
+    if process is None:
+        return False
+
+    if not process.is_alive():
+        _OCR_SERVER_PROCESS = None
+        return False
+
+    logger.info("Stopping OCR server process")
+    try:
+        process.terminate()
+        process.join(timeout=timeout)
+        if process.is_alive():
+            logger.warning("OCR server process did not exit in time, force killing")
+            process.kill()
+            process.join(timeout=1.0)
+        logger.info("OCR server process stopped")
+        return True
+    except Exception as e:
+        logger.exception(e)
+        return False
+    finally:
+        _OCR_SERVER_PROCESS = None
 
 
 def run_ocr_server(host: str, port: int) -> None:
@@ -176,3 +205,6 @@ class ModelProxy:
             BoxedResult(np.array(item["box"]), None, item["ocr_text"], item["score"])
             for item in results
         ]
+
+
+atexit.register(shutdown_ocr_server)

--- a/module/server/home_router.py
+++ b/module/server/home_router.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from module.config.utils import write_file
 from module.logger import logger
+from module.ocr.rpc import shutdown_ocr_server
 from module.server.main_manager import MainManager
 from module.server.updater import Updater
 from module.server.i18n import I18n
@@ -46,6 +47,7 @@ async def notify_test(setting: str, title: str, content: str):
 
 @home_app.get('/kill_server')
 async def kill_server():
+    shutdown_ocr_server()
     MainManager.signal_kill_server = True
     return 'success'
 

--- a/script.py
+++ b/script.py
@@ -35,6 +35,7 @@ from module.base.decorator import del_cached_property
 from module.logger import logger
 from module.exception import *
 from module.server.i18n import I18n
+from module.ocr.rpc import ensure_ocr_server_started
 
 
 
@@ -547,5 +548,6 @@ class Script:
 
 
 if __name__ == "__main__":
+    ensure_ocr_server_started()
     script = Script("oas1")
     script.loop()

--- a/server.py
+++ b/server.py
@@ -28,7 +28,7 @@ import threading
 
 from module.logger import logger
 from module.server.setting import State
-from module.ocr.rpc import ensure_ocr_server_started
+from module.ocr.rpc import ensure_ocr_server_started, shutdown_ocr_server
 
 
 def fun(ev: threading.Event):
@@ -82,10 +82,13 @@ def fun(ev: threading.Event):
 
     ensure_ocr_server_started()
 
-    uvicorn.run("module.server.app:fastapi_app",
-                host=host,
-                port=port,
-                factory=True)
+    try:
+        uvicorn.run("module.server.app:fastapi_app",
+                    host=host,
+                    port=port,
+                    factory=True)
+    finally:
+        shutdown_ocr_server()
 
 
 if __name__ == "__main__":

--- a/server.py
+++ b/server.py
@@ -28,6 +28,8 @@ import threading
 
 from module.logger import logger
 from module.server.setting import State
+from module.ocr.rpc import ensure_ocr_server_started
+
 
 def fun(ev: threading.Event):
     import argparse
@@ -78,13 +80,13 @@ def fun(ev: threading.Event):
     logger.attr("Port", port)
     logger.attr("Reload", ev is not None)
 
+    ensure_ocr_server_started()
+
     uvicorn.run("module.server.app:fastapi_app",
                 host=host,
                 port=port,
                 factory=True)
 
 
-
 if __name__ == "__main__":
     fun(None)
-

--- a/tasks/SixRealms/oas_ocr.py
+++ b/tasks/SixRealms/oas_ocr.py
@@ -33,6 +33,12 @@ class VerticalText(BaseCor):
         return image
 
     def detect_and_ocr(self, *args, **kwargs):
+        if getattr(self.model, "is_proxy", False):
+            params = {"drop_score": 0.1, "box_thresh": 0.2, "vertical": True}
+            for key in list(params.keys()):
+                if key in kwargs:
+                    params.pop(key)
+            return self.model.detect_and_ocr(*args, **params, **kwargs)
         # Try hard to lower TextSystem.box_thresh
         backup = self.model.text_detector.box_thresh
         # Patch text_recognizer


### PR DESCRIPTION
#### 开启后ocr_server后所有脚本共用一个ocr服务，提升ocr效率，降低内存占用。不开启则依旧使用旧逻辑

- 新增rpc.py文件实现OCR服务端和客户端代理类
- 添加ensure_ocr_server_started函数用于启动OCR服务器进程
- 修改base_ocr.py使用get_ocr_model工厂函数获取模型实例
- 更新models.py添加ModelProxy和OCR模型缓存机制
- 在gui.py、script.py和server.py中添加OCR服务启动检查
- 实现detect_and_ocr方法支持远程调用参数传递
- 添加Socket端口检测和多进程管理功能