### PR TITLE
fix(ActivityShikigami): 优化爬塔结算点击逻辑

### DIFF
--- a/tasks/ActivityShikigami/script_task.py
+++ b/tasks/ActivityShikigami/script_task.py
@@ -258,7 +258,7 @@ class ScriptTask(StateMachine, GameUi, BaseActivity, SwitchSoul, ActivityShikiga
         logger.hr(f'Start run climb type AP100')
 
     def start_battle(self):
-        click_times, max_times = 0, random.randint(2, 4)
+        click_times, max_times = 0, random.randint(4, 8)
         while 1:
             self.screenshot()
             if self.is_in_battle(False):
@@ -284,7 +284,7 @@ class ScriptTask(StateMachine, GameUi, BaseActivity, SwitchSoul, ActivityShikiga
         self.count_map[self.climb_type] = self.current_count
         for btn in (self.C_RANDOM_LEFT, self.C_RANDOM_RIGHT, self.C_RANDOM_TOP, self.C_RANDOM_BOTTOM):
             btn.name = "BATTLE_RANDOM"
-        ok_cnt, max_retry = 0, 5
+        ok_cnt, max_retry = 0, 8
         while 1:
             sleep(random.uniform(0.5, 1.5))
             self.screenshot()
@@ -305,12 +305,13 @@ class ScriptTask(StateMachine, GameUi, BaseActivity, SwitchSoul, ActivityShikiga
             #  出现 “魂” 和 紫蛇皮
             if self.appear(self.I_REWARD) or self.appear(self.I_REWARD_PURPLE_SNAKE_SKIN) or \
                     self.appear(self.I_REWARD_GOLD) or self.appear(self.I_REWARD_GOLD_SNAKE_SKIN):
-                self.random_reward_click(exclude_click=[self.C_RANDOM_RIGHT])
+                self.random_reward_click(exclude_click=[self.C_RANDOM_TOP, self.C_RANDOM_LEFT])
                 ok_cnt += 1
                 continue
             # 已经不在战斗中了, 且奖励也识别过了, 则随机点击
-            if ok_cnt > 0 and not self.is_in_battle(False):
-                self.random_reward_click(exclude_click=[self.C_RANDOM_RIGHT])
+            if ok_cnt > 3 and not self.is_in_battle(False):
+                self.random_reward_click(exclude_click=[self.C_RANDOM_TOP, self.C_RANDOM_LEFT])
+                self.device.stuck_record_clear()
                 ok_cnt += 1
                 continue
             # 战斗中随机滑动


### PR DESCRIPTION
- 增加开始战斗的最大重试次数
- 将最大重试次数从 5 增加到 8
- 修改了随机奖励点击的排除区域配置
- 调整了奖励识别后的继续条件判断逻辑
- 在非战斗状态时清除设备卡死记录