### PR TITLE
fix(MemoryScrolls): 提高图像识别阈值以改善准确性

### DIFF
--- a/tasks/MemoryScrolls/assets.py
+++ b/tasks/MemoryScrolls/assets.py
@@ -55,7 +55,7 @@ class MemoryScrollsAssets:
 	# 小碎片 
 	I_MS_FRAGMENT_S = RuleImage(roi_front=(290,677,40,35), roi_back=(290,677,40,35), threshold=0.8, method="Template matching", file="./tasks/MemoryScrolls/ms/ms_ms_fragment_s.png")
 	# 小碎片满50 
-	I_MS_FRAGMENT_S_50 = RuleImage(roi_front=(473,517,60,25), roi_back=(473,517,60,25), threshold=0.8, method="Template matching", file="./tasks/MemoryScrolls/ms/ms_ms_fragment_s_50.png")
+	I_MS_FRAGMENT_S_50 = RuleImage(roi_front=(473,517,60,25), roi_back=(473,517,60,25), threshold=0.9, method="Template matching", file="./tasks/MemoryScrolls/ms/ms_ms_fragment_s_50.png")
 	# description 
 	I_MS_FRAGMENT_S_VERIFICATION = RuleImage(roi_front=(522,318,100,100), roi_back=(522,318,100,100), threshold=0.8, method="Template matching", file="./tasks/MemoryScrolls/ms/ms_ms_fragment_s_verification.png")
 	# 双绘卷进入按钮 

--- a/tasks/MemoryScrolls/ms/image.json
+++ b/tasks/MemoryScrolls/ms/image.json
@@ -113,7 +113,7 @@
     "roiFront": "473,517,60,25",
     "roiBack": "473,517,60,25",
     "method": "Template matching",
-    "threshold": 0.8,
+    "threshold": 0.9,
     "description": "小碎片满50"
   },
   {


### PR DESCRIPTION
测试的时候好多没有达到50/50的数据都能匹配到0.8多一点

## Summary by Sourcery

Bug Fixes:
- 调整 MemoryScrolls 中 50% 小碎片图像的识别阈值，以避免在数据量较少时出现错误匹配。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Adjust the recognition threshold for the small fragment 50% image in MemoryScrolls to avoid incorrect matches on low-amount data.

</details>