### PR TITLE
Dev6

### DIFF
--- a/tasks/DemonEncounter/config.py
+++ b/tasks/DemonEncounter/config.py
@@ -45,8 +45,7 @@ class DemonConfig(BaseModel):
         description="通过预设名称来匹配普通封魔御魂分组\n例如=> 逢魔之时,歌(中间的是英文逗号)",
     )
     # 周一
-    demon_kiryou_utahime: str = Field(default="group,team", description="鬼灵歌姬御魂1")
-    demon_kiryou_utahime_supplementary: str = Field(default="group,team", description="鬼灵歌姬御魂补充")
+    demon_kiryou_utahime: str = Field(default="group,team", description="鬼灵歌姬御魂")
     # 周二
     demon_shinkirou: str = Field(default="group,team", description="蜃气楼御魂")
     # 周三 土蜘蛛
@@ -67,8 +66,7 @@ class BestDemonConfig(BaseModel):
         default=False,
         description="通过预设名称来匹配极封魔御魂分组\n例如=> 逢魔之时,歌(中间的是英文逗号)",
     )
-    best_demon_kiryou_utahime: str = Field(default="group,team", description="极鬼灵歌姬御魂1")
-    best_demon_kiryou_utahime_supplementary: str = Field(default="group,team", description="极鬼灵歌姬御魂补充")
+    best_demon_kiryou_utahime: str = Field(default="group,team", description="极鬼灵歌姬御魂")
     best_demon_shinkirou: str = Field(default="group,team", description="极蜃气楼御魂")
     best_demon_tsuchigumo: str = Field(default="group,team", description="极土蜘蛛御魂")
     best_demon_gashadokuro: str = Field(default="group,team", description="极荒骷髅御魂")
@@ -76,8 +74,8 @@ class BestDemonConfig(BaseModel):
     best_demon_oboroguruma: str = Field(default="group,team", description="极胧车御魂")
     best_demon_nightly_aramitamau: str = Field(default="group,team", description="极夜荒魂御魂")
 
-    hide_fields = dynamic_hide('best_demon_kiryou_utahime', 'best_demon_kiryou_utahime_supplementary',
-                               'best_demon_oboroguruma', 'best_demon_nightly_aramitamau')
+    hide_fields = dynamic_hide('best_demon_kiryou_utahime', 'best_demon_oboroguruma',
+                               'best_demon_nightly_aramitamau')
 
 
 def convert_to_general_battle_config(boss_type: str, demon_battle_conf: 'DemonBattleConfig' = None,

--- a/tasks/DemonEncounter/script_task.py
+++ b/tasks/DemonEncounter/script_task.py
@@ -65,12 +65,8 @@ class ScriptTask(GameUi, GeneralBattle, DemonEncounterAssets, SwitchSoul):
             group, team = getattr(self.conf.demon_soul_config, self.boss_type).split(",")
         if group and team:
             self.run_switch_soul_by_name(group, team)
-            if datetime.now().weekday() == 0:
-                if select_best_demon:
-                    group, team = getattr(self.conf.best_demon_soul_config, f'{self.boss_type}_supplementary').split(",")
-                else:
-                    group, team = getattr(self.conf.demon_soul_config, f'{self.boss_type}_supplementary').split(",")
-                self.run_switch_soul_by_name(group, team)
+            return
+        logger.error(f'Unknown switch soul conf: group[{group}], team[{team}]')
 
     def execute_boss(self):
         """

--- a/tasks/SixRealms/config.py
+++ b/tasks/SixRealms/config.py
@@ -17,8 +17,7 @@ class SixRealmsGate(BaseModel):
 
 class SixRealms(ConfigBase):
     scheduler: Scheduler = Field(default_factory=Scheduler)
-    switch_soul_config_1: SwitchSoulConfig = Field(default_factory=SwitchSoulConfig)
-    switch_soul_config_2: SwitchSoulConfig = Field(default_factory=SwitchSoulConfig)
+    switch_soul_config: SwitchSoulConfig = Field(default_factory=SwitchSoulConfig)
     six_realms_gate: SixRealmsGate = Field(default_factory=SixRealmsGate)
 
 

--- a/tasks/SixRealms/script_task.py
+++ b/tasks/SixRealms/script_task.py
@@ -31,28 +31,14 @@ class ScriptTask(GameUi, SwitchSoul, MoonSea):
         return self.config.model.six_realms
 
     def run(self):
-        if self._config.switch_soul_config_1.enable:
+        if self._config.switch_soul_config.enable:
             self.ui_get_current_page()
             self.ui_goto(page_shikigami_records)
-            self.run_switch_soul(self._config.switch_soul_config_1.switch_group_team)
-        if self._config.switch_soul_config_1.enable_switch_by_name:
+            self.run_switch_soul(self._config.switch_soul_config.switch_group_team)
+        if self._config.switch_soul_config.enable_switch_by_name:
             self.ui_get_current_page()
             self.ui_goto(page_shikigami_records)
-            self.run_switch_soul_by_name(
-                self._config.switch_soul_config_1.group_name,
-                self._config.switch_soul_config_1.team_name
-            )
-        if self._config.switch_soul_config_2.enable:
-            self.ui_get_current_page()
-            self.ui_goto(page_shikigami_records)
-            self.run_switch_soul(self._config.switch_soul_config_2.switch_group_team)
-        if self._config.switch_soul_config_2.enable_switch_by_name:
-            self.ui_get_current_page()
-            self.ui_goto(page_shikigami_records)
-            self.run_switch_soul_by_name(
-                self._config.switch_soul_config_2.group_name,
-                self._config.switch_soul_config_2.team_name
-            )
+            self.run_switch_soul_by_name(self._config.switch_soul_config.group_name, self._config.switch_soul_config.team_name)
         self.ui_get_current_page()
         self.ui_goto(page_six_gates)
 


### PR DESCRIPTION
## Summary by Sourcery

将六道轮回的灵魂切换配置统一为一个配置项，并简化针对桐生歌姬（Kiryou Utahime）Boss 的魔物遭遇（Demon Encounter）灵魂选择逻辑。

Bug 修复：
- 通过移除未使用的附加预设，并在遇到无效配置时记录日志而不是静默继续执行，修正魔物遭遇中的灵魂选择问题。

增强改进：
- 将六道轮回的灵魂切换从两个独立配置合并为一个统一的 `switch_soul_config`。
- 通过移除附加的组/队伍字段并更新相关的动态字段隐藏规则，简化魔物遭遇中桐生歌姬（Kiryou Utahime）的配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify Six Realms soul-switch configuration to a single config entry and simplify Demon Encounter soul selection for Kiryou Utahime bosses.

Bug Fixes:
- Correct Demon Encounter soul selection by removing unused supplementary presets and logging invalid configurations instead of silently proceeding.

Enhancements:
- Consolidate Six Realms soul switching from two separate configs into one unified switch_soul_config.
- Simplify Demon Encounter Kiryou Utahime configuration by removing supplementary group/team fields and updating related dynamic field hiding.

</details>