### PR TITLE
fix(config):增加功能，waiting_task队列清空后使用notify推送下一次任务预定的运行时间

### DIFF
--- a/module/config/config.py
+++ b/module/config/config.py
@@ -233,6 +233,9 @@ class Config(ConfigState, ConfigManual, ConfigWatcher, ConfigMenu):
         if self.waiting_task:
             logger.info("No task pending")
             task = copy.deepcopy(self.waiting_task[0])
+            next_task = self.waiting_task[0]
+            next_time = next_task.next_run.strftime("%Y-%m-%d %H:%M:%S")
+            self.notifier.push(title="等待中", content=f"下一个任务：{next_task.command}，预定运行时间：{next_time}")
             # task.next_run = (task.next_run + self.hoarding).replace(microsecond=0)
             logger.attr("Task", task)
             return task


### PR DESCRIPTION
方便和手机协同，避免手机上玩京铲铲下到一半被抢登录

## Summary by Sourcery

增强内容：
- 当使用等待任务队列时，发送一条通知，显示下一个等待任务以及其计划运行时间。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Send a notification showing the next waiting task and its scheduled run time when the waiting task queue is used.

</details>