### PR TITLE
fix(Exploration): 将返回按钮图像资源从红色改为黄色

### DIFF
--- a/tasks/Exploration/base.py
+++ b/tasks/Exploration/base.py
@@ -357,7 +357,7 @@ class BaseExploration(GameUi, GeneralBattle, GeneralRoom, GeneralInvite, Replace
         logger.info("RealmRaid and Exploration  set_next_run !")
         next_run = datetime.now() + con_scrolls.scrolls_cd
         self.set_next_run(task='Exploration', success=False, finish=False, target=next_run)
-        self.set_next_run(task='RealmRaid', success=False, finish=False, target=datetime.now())
+        self.set_next_run(task='RealmRaid', success=False, finish=False, server=False, target=datetime.now())
         self.set_next_run(task='MemoryScrolls', success=False, finish=False, target=datetime.now())
         raise TaskEnd
 

--- a/tasks/Exploration/base.py
+++ b/tasks/Exploration/base.py
@@ -383,7 +383,7 @@ class BaseExploration(GameUi, GeneralBattle, GeneralRoom, GeneralInvite, Replace
             self.screenshot()
             
             # 探索章节标题界面
-            if self.appear(self.I_UI_BACK_RED) and self.appear(self.I_E_EXPLORATION_CLICK):
+            if self.appear(self.I_UI_BACK_YELLOW) and self.appear(self.I_E_EXPLORATION_CLICK):
                 break
             # 探索大世界界面
             if self.appear(self.I_CHECK_EXPLORATION) and not self.appear(self.I_E_SETTINGS_BUTTON):

--- a/tasks/Exploration/solo.py
+++ b/tasks/Exploration/solo.py
@@ -35,15 +35,18 @@ class SoloExploration(BaseExploration):
         while 1:
             self.screenshot()
             scene = self.get_current_scene()
-
+            logger.info(f'[run_solo] Current scene: {scene.name}')
             #
             if scene == Scene.WORLD:
                 # 打开右边箭头
-                self.ui_click(click=self.I_EXP_ARROW_LEFT, stop=self.I_EXP_ARROW_RIGHT, interval=2)
+                self.ui_click(click=self.I_EXP_ARROW_LEFT, stop=self.I_EXP_ARROW_RIGHT, interval=2, timeout=3)
                 if self.appear(self.I_TREASURE_BOX_CLICK):
                     # 宝箱
                     logger.info('Treasure box appear, get it.')
                     self.ui_click_until_disappear(self.I_TREASURE_BOX_CLICK)
+                # 处理识别页面出错的情况
+                if not self.appear(self.I_CHECK_EXPLORATION):
+                    continue
                 if self.check_exit():
                     break
                 self.open_expect_level()
@@ -106,11 +109,15 @@ class SoloExploration(BaseExploration):
         while 1:
             self.screenshot()
             scene = self.get_current_scene()
+            logger.info(f'[run_leader] Current scene: {scene.name}')
             # 探索大世界
             if scene == Scene.WORLD:
-                self.wait_until_stable(self.I_CHECK_EXPLORATION)
+                self.wait_until_stable(self.I_CHECK_EXPLORATION, timeout=5)
                 # 打开右边箭头
-                self.ui_click(click=self.I_EXP_ARROW_LEFT, stop=self.I_EXP_ARROW_RIGHT, interval=2)
+                self.ui_click(click=self.I_EXP_ARROW_LEFT, stop=self.I_EXP_ARROW_RIGHT,timeout=3, interval=2)
+                # 处理识别页面出错的情况
+                if not self.appear(self.I_CHECK_EXPLORATION):
+                    continue
                 if self.appear(self.I_TREASURE_BOX_CLICK):
                     # 宝箱
                     logger.info('Treasure box appear, get it.')
@@ -240,10 +247,14 @@ class SoloExploration(BaseExploration):
         while 1:
             self.screenshot()
             scene = self.get_current_scene()
+            logger.info(f'[run_member] Current scene: {scene.name}')
             #
             if scene == Scene.WORLD:
                 # 打开右边箭头
                 self.ui_click(click=self.I_EXP_ARROW_LEFT, stop=self.I_EXP_ARROW_RIGHT, interval=2)
+                # 处理识别页面出错的情况
+                if not self.appear(self.I_CHECK_EXPLORATION):
+                    continue
                 if self.appear(self.I_TREASURE_BOX_CLICK):
                     # 宝箱
                     logger.info('Treasure box appear, get it.')
@@ -295,6 +306,7 @@ class SoloExploration(BaseExploration):
                     friend_leave_timer = Timer(10)
             #
             elif scene == Scene.BATTLE_PREPARE or scene == Scene.BATTLE_FIGHTING:
+                logger.info('[run_member] Handling scene: BATTLE')
                 self.check_take_over_battle(is_screenshot=False, config=self._config.general_battle_config)
             elif scene == Scene.UNKNOWN:
                 continue

--- a/tasks/Exploration/solo.py
+++ b/tasks/Exploration/solo.py
@@ -260,7 +260,7 @@ class SoloExploration(BaseExploration):
                 continue
             #
             elif scene == Scene.ENTRANCE:
-                self.ui_click_until_disappear(self.I_UI_BACK_RED)
+                self.ui_click(self.I_UI_BACK_YELLOW,stop=self.I_CHECK_EXPLORATION)
             #
             elif scene == Scene.TEAM:
                 continue


### PR DESCRIPTION
领取完纸人后会有几帧出现在探索界面，后弹出关卡界面，导致识别页面出错，该提交能解决问题，但这种情况出现的概率不小，感觉有点浪费时间，可以改进下
## Summary by Sourcery

错误修复：
- 通过将返回按钮的检测和点击逻辑从已弃用的红色图标切换到当前的黄色图标，修复探索退出和进入流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix exploration quit and entrance flows by switching back button detection and clicks from the deprecated red icon to the current yellow icon.

</details>