### PR TITLE
fix(GameUi): 修正登录页面元素列表  #1607

### DIFF
--- a/tasks/GameUi/page.py
+++ b/tasks/GameUi/page.py
@@ -54,8 +54,8 @@ page_login = Page(G.I_CHECK_LOGIN_FORM)
 # Main Home 主页
 page_main = Page(G.I_CHECK_MAIN)
 page_main.additional = [G.I_AD_CLOSE_RED, G.I_BACK_FRIENDS, RestartAssets.I_CANCEL_BATTLE,
-                        [RestartAssets.I_LOGIN_COURTYARD, RestartAssets.C_LOGIN_SCROLL_CLOSE_AREA,
-                         G.I_CLOSE_CHAT_WINDOW]]
+                        [RestartAssets.I_LOGIN_COURTYARD, RestartAssets.C_LOGIN_SCROLL_CLOSE_AREA],
+                            GGA.I_CHAT_CLOSE_BUTTON]
 # 召唤summon
 page_summon = Page(G.I_CHECK_SUMMON)
 page_summon.link(button=G.I_SUMMON_GOTO_MAIN, destination=page_main)

--- a/tasks/GameUi/page.py
+++ b/tasks/GameUi/page.py
@@ -55,7 +55,7 @@ page_login = Page(G.I_CHECK_LOGIN_FORM)
 page_main = Page(G.I_CHECK_MAIN)
 page_main.additional = [G.I_AD_CLOSE_RED, G.I_BACK_FRIENDS, RestartAssets.I_CANCEL_BATTLE,
                         [RestartAssets.I_LOGIN_COURTYARD, RestartAssets.C_LOGIN_SCROLL_CLOSE_AREA],
-                            GGA.I_CHAT_CLOSE_BUTTON]
+                            GGA.I_CHAT_CLOSE_BUTTON, G.I_CLOSE_CHAT_WINDOW]
 # 召唤summon
 page_summon = Page(G.I_CHECK_SUMMON)
 page_summon.link(button=G.I_SUMMON_GOTO_MAIN, destination=page_main)


### PR DESCRIPTION
- 修复页面元素匹配列表的括号闭合错误
- 调整登录场景的关闭按钮引用，避免匹配异常

## Summary by Sourcery

修复主页面定义中的登录场景 UI 元素配置。

Bug 修复：
- 更正主页面元素列表的结构，以避免分组不匹配的问题。
- 更新登录场景关闭按钮的引用，使用正确的聊天关闭元素，防止匹配错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix login scene UI element configuration in the main page definition.

Bug Fixes:
- Correct the structure of the main page element list to avoid mismatched grouping.
- Update the login scene close button reference to use the proper chat close element and prevent matching errors.

</details>