### PR TITLE
feat: 同步 next_monday、任务结束关机、单次领奖卡住与道馆建馆修复 (#2)

### DIFF
--- a/module/config/argument/args.json
+++ b/module/config/argument/args.json
@@ -193,7 +193,8 @@
         "option": [
           "stay_there",
           "goto_main",
-          "close_game"
+          "close_game",
+          "close_computer"
         ]
       }
     },

--- a/module/config/argument/argument.yaml
+++ b/module/config/argument/argument.yaml
@@ -60,7 +60,7 @@ Optimization:
   TaskHoardingDuration: 0
   WhenTaskQueueEmpty:
     value: goto_main
-    option: [ stay_there, goto_main, close_game ]
+    option: [ stay_there, goto_main, close_game, close_computer ]
 DropRecord:
   SaveFolder: ./screenshots
   AzurStatsID: null

--- a/module/config/config.py
+++ b/module/config/config.py
@@ -356,10 +356,15 @@ class Config(ConfigState, ConfigManual, ConfigWatcher, ConfigMenu):
                              scheduler.float_time.second)
             random_float = random.randint(0, float_seconds)
             # 如果有强制运行时间
-            if scheduler.server_update == time(hour=9):
+            if scheduler.server_update == time(hour=9) or target is not None:
                 next_run += timedelta(seconds=random_float)
             else:
                 next_run = parse_tomorrow_server(scheduler.server_update, scheduler.delay_date, random_float)
+
+        if hasattr(scheduler, 'next_monday') and scheduler.next_monday:
+            today = next_run - timedelta(days=1)
+            days_until_monday = (7 - today.weekday()) % 7 or 7
+            next_run = today + timedelta(days=days_until_monday)
 
         # 将这些连接起来，方便日志输出
         kv = dict_to_kv(

--- a/script.py
+++ b/script.py
@@ -330,6 +330,7 @@ class Script:
         strategy_map = {
             "close_game": self._wait_close_game,
             "goto_main": self._wait_goto_main,
+            "close_computer": self._wait_close_computer,
         }
         func = strategy_map.get(method)
         if func is None:
@@ -435,6 +436,11 @@ class Script:
         logger.info("Goto main page during wait")
         self.run("GotoMain")
         self.device.release_during_wait()
+        return self.wait_until(next_run)
+
+    def _wait_close_computer(self, next_run: datetime) -> bool:
+        logger.info("Close computer during wait")
+        os.system('shutdown /s /t 1')
         return self.wait_until(next_run)
 
     def _wait_stay_there(self, next_run: datetime) -> bool:

--- a/tasks/CollectiveMissions/script_task.py
+++ b/tasks/CollectiveMissions/script_task.py
@@ -264,8 +264,9 @@ class ScriptTask(GameUi, CollectiveMissionsAssets):
                 raise RequestHumanTakeover
 
         logger.info('Swipe to the most matter')
-        # 还有一点很重要的，捐赠会有双倍的，需要领两次
+        # 双倍活动时会领两次；若只有单次奖励，超时后继续避免卡死
         reward_number = 0
+        second_reward_wait = None
         while 1:
             self.screenshot()
 
@@ -273,7 +274,13 @@ class ScriptTask(GameUi, CollectiveMissionsAssets):
                 break
             if self.ui_reward_appear_click(False):
                 reward_number += 1
+                if reward_number == 1:
+                    second_reward_wait = Timer(10)
+                    second_reward_wait.start()
                 continue
+            if reward_number == 1 and second_reward_wait is not None and second_reward_wait.reached():
+                logger.info('Donate: only one reward popup; skip waiting for double')
+                break
             if self.appear_then_click(self.I_CM_PRESENT, interval=1):
                 continue
         self.ui_reward_appear_click(True)
@@ -362,8 +369,8 @@ class ScriptTask(GameUi, CollectiveMissionsAssets):
             for click in click_list:
                 self.click(click)
         logger.info('Finish to feed soul')
-        # 还有一点很重要的，捐赠会有双倍的，需要领两次
         reward_number = 0
+        second_reward_wait = None
         while 1:
             self.screenshot()
 
@@ -371,7 +378,13 @@ class ScriptTask(GameUi, CollectiveMissionsAssets):
                 break
             if self.ui_reward_appear_click(False):
                 reward_number += 1
+                if reward_number == 1:
+                    second_reward_wait = Timer(10)
+                    second_reward_wait.start()
                 continue
+            if reward_number == 1 and second_reward_wait is not None and second_reward_wait.reached():
+                logger.info('Feed: only one reward popup; skip waiting for double')
+                break
             if self.appear_then_click(self.I_FEED_SUBMIT, interval=1):
                 continue
         self.ui_reward_appear_click(True)

--- a/tasks/Component/config_scheduler.py
+++ b/tasks/Component/config_scheduler.py
@@ -12,6 +12,7 @@ class Scheduler(ConfigBase):
 
     success_interval: TimeDelta = Field(default=TimeDelta(days=1), description='success_interval_help')
     failure_interval: TimeDelta = Field(default=TimeDelta(days=1), description='failure_interval_help')
+    next_monday: bool = Field(default=False)
     server_update: Time = Field(default=Time(hour=9, minute=0, second=0), description='server_update_help')
     delay_date: int = Field(default=1, description='delay_date_help', ge=1, le=31)
     float_time: Time = Field(default=Time(hour=0, minute=0, second=0), description='float_time_help')
@@ -24,6 +25,7 @@ if __name__ == "__main__":
         "priority": 5,
         "success_interval": "10 00:00:01",
         "failure_interval": "10 00:00:01",
+        "next_monday": False,
         "server_update": "09:03:00",
         "float_time": "02:00:05"
     }

--- a/tasks/Dokan/script_task.py
+++ b/tasks/Dokan/script_task.py
@@ -140,9 +140,9 @@ class ScriptTask(ExtendGreenMark, GameUi, SwitchSoul, DokanSceneDetector):
                 if not try_start_dokan:
                     is_dokan_activated = False
                     break
-                # NOTE 只在周一尝试建立道馆
-                if datetime.now().weekday() == 0:
-                    self.creat_dokan()
+
+                # 尝试建立道馆
+                self.creat_dokan()
 
                 # 寻找合适道馆,找不到直接退出
                 if not self.find_dokan(self.config.dokan.dokan_config.find_dokan_score):

--- a/tasks/Script/config_optimization.py
+++ b/tasks/Script/config_optimization.py
@@ -10,6 +10,7 @@ from tasks.Component.config_base import Time
 class WhenTaskQueueEmpty(str, Enum):
     GOTO_MAIN = 'goto_main'
     CLOSE_GAME = 'close_game'
+    CLOSE_COMPUTER = 'close_computer'
 
 class ScheduleRule(str, Enum):
     FILTER = 'Filter'  # 默认的基于过滤器，（按照开发者设定的调度规则进行调度）


### PR DESCRIPTION
* feat(Scheduler): 添加 next_monday 运行支持



* feat(Wait): 添加任务完毕关闭电脑选项



* fix(CollectiveMissions): 修复单次领奖时循环等待卡住



* fix(Dokan): 优化道馆建立逻辑，移除周一限制



---------

## 由 Sourcery 生成的摘要

新增可选的下周一调度功能、支持任务完成后关闭电脑、修复单次领取任务奖励导致卡住的问题，并放宽 Dokan 创建对工作日的限制。

新功能：
- 引入调度器标志，用于将下次运行延迟到下一个周一。
- 新增配置选项，当任务队列为空时关闭电脑。

错误修复：
- 在集体任务的捐赠和喂食流程中，当只有一个奖励弹窗出现时，避免出现无限等待的情况。
- 通过移除工作日限制，允许在非周一创建 Dokan。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add optional next-Monday scheduling, support shutting down the computer after tasks complete, prevent single-claim mission rewards from hanging, and relax Dokan creation weekday constraints.

New Features:
- Introduce a scheduler flag to delay next runs until the next Monday.
- Add a configuration option to shut down the computer when the task queue is empty.

Bug Fixes:
- Avoid infinite waiting when only a single reward popup appears in Collective Missions donation and feeding flows.
- Allow Dokan creation outside of Monday by removing the weekday restriction.

</details>