### PR TITLE
fix(AutoCheckinBigGod): 修复DeviceId获取失败问题，兼容大神APP新版本

### DIFF
--- a/tasks/AutoCheckinBigGod/script_task.py
+++ b/tasks/AutoCheckinBigGod/script_task.py
@@ -839,12 +839,19 @@ Java.perform(function() {{
         return None
 
     def _get_device_id(self, pid):
-        """通过 Frida 获取 DeviceId"""
+        """通过 Frida 获取 DeviceId，失败时使用UDID作为备选"""
         script = """
 Java.perform(function() {
     try {
         var YXFDeviceInfo = Java.use('com.netease.gl.glbase.build.YXFDeviceInfo');
-        console.log('GL_DEVICEID:' + YXFDeviceInfo.getDeviceId());
+        var id = YXFDeviceInfo.getDeviceId();
+        if (id && typeof id === 'string' && id != 'unknown') console.log('GL_DEVICEID:' + id);
+    } catch(e) {}
+    try {
+        var ctx = Java.use('android.app.ActivityThread').currentApplication().getApplicationContext();
+        var sp = ctx.getSharedPreferences('gl_user_info', 0);
+        var deviceId = sp.getString('deviceId', '');
+        if (deviceId && deviceId != 'unknown') console.log('GL_DEVICEID:' + deviceId);
     } catch(e) {}
     console.log('__DONE__');
 });
@@ -853,7 +860,18 @@ Java.perform(function() {
         if output:
             for line in output.split('\n'):
                 if 'GL_DEVICEID:' in line:
-                    return line.split('GL_DEVICEID:')[1].strip()
+                    device_id = line.split('GL_DEVICEID:')[1].strip()
+                    if device_id and device_id != 'unknown' and not device_id.startswith('Java.Field'):
+                        return device_id
+        
+        try:
+            udid = self._adb_shell(['settings', 'get', 'secure', 'android_id'])
+            if udid and udid != 'unknown':
+                logger.info(f'使用UDID作为DeviceId')
+                return udid
+        except Exception:
+            pass
+        
         return None
 
     def _login_by_urs_token(self, pid, urs_creds):
@@ -1120,3 +1138,10 @@ Java.perform(function() {
             logger.error(f'  领取异常: {title} - {e}')
 
         return False
+if __name__ == "__main__":
+    from module.config.config import Config
+    from module.device.device import Device
+    config = Config('oas1')
+    device = Device(config)
+    t = ScriptTask(config, device)
+    t.run()


### PR DESCRIPTION
- 问题原因：大神APP 4.18.2版本中，原有的YXFDeviceInfo.getDeviceId()返回空值，导致登录API返回参数错误
- 解决方案：精简了_get_device_id函数的Frida脚本，保留核心逻辑
- 增加UDID作为备选方案（使用android_id）
- 当Frida获取失败时，自动使用settings get secure android_id作为DeviceId

## Summary by Sourcery

改进 AutoCheckinBigGod 设备识别方式，以保持与新版大神 app 的兼容性，并使任务脚本可以直接运行。

Bug 修复：
- 处理 `YXFDeviceInfo.getDeviceId()` 返回空值或无效值的情况，防止登录参数出错。

增强功能：
- 回退逻辑：优先读取应用中存储的 `deviceId`，如果不可用，则使用系统 UDID（`android_id`）作为备用 DeviceId。
- 新增主入口点，以便可以直接运行 `ScriptTask`，用于本地执行或调试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve AutoCheckinBigGod device identification to remain compatible with newer versions of the 大神 app and make the task script directly runnable.

Bug Fixes:
- Handle cases where YXFDeviceInfo.getDeviceId() returns empty or invalid values to prevent login parameter errors.

Enhancements:
- Fallback to reading the app-stored deviceId and, if unavailable, use the system UDID (android_id) as a backup DeviceId.
- Add a main entry point to run ScriptTask directly for local execution or debugging.

</details>