### PR TITLE
Security: Potential Command Injection in Process Execution

### DIFF
--- a/deploy/process.py
+++ b/deploy/process.py
@@ -58,7 +58,7 @@ class ProcessManager(DeployConfig):
         logger.hr(f'Kill {name}', 1)
         for row in self.iter_process_by_name(name):
             logger.info(' '.join(map(str, row)))
-            self.execute(f'taskkill /f /pid {row[2]}', allow_failure=True, output=False)
+            self.execute(['taskkill', '/f', '/pid', str(row[2])], allow_failure=True, output=False)
 
     def process_kill(self):
         logger.hr(f'Kill existing Alas', 0)


### PR DESCRIPTION
## Summary

Security: Potential Command Injection in Process Execution

## Problem

**Severity**: `High` | **File**: `deploy/process.py:L56`

The `execute` method in ProcessManager constructs and executes shell commands using string formatting with external inputs. While the specific `execute` implementation is not fully shown, the pattern of building command strings with `f'taskkill /f /pid {row[2]}'` and similar constructs in `pip_install` with user-configurable mirrors suggests potential for command injection if inputs are not properly sanitized.

## Solution

Use subprocess with argument lists instead of string formatting for shell commands. Validate and sanitize all inputs that are incorporated into commands. Consider using `subprocess.run` with a list of arguments rather than shell=True to prevent injection attacks.

## Changes

- `deploy/process.py` (modified)

## Summary by Sourcery

Bug Fixes:
- 在进程终止逻辑中调用 `taskkill` 时，使用参数列表执行方式，而不是格式化后的 shell 命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Use argument list execution instead of formatted shell command when invoking taskkill in process termination logic.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了进程终止命令的执行方式，提升了命令传参的稳定性与一致性。
  * 仍可按目标进程 ID 强制结束进程，行为保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->