### PR TITLE
fix(Login): 登陆时可展开卷轴

### DIFF
--- a/tasks/Restart/login.py
+++ b/tasks/Restart/login.py
@@ -49,6 +49,11 @@ class LoginHandler(BaseTask, RestartAssets, GameUiAssets):
                     logger.info('Click scroll close area because courtyard appears')
                     self.screenshot()  # 点击后立即获取最新截图，确保后续状态检查准确
                     continue
+            # 确认进入庭院(兜底：未检测到闲庭图片时，如果识别到卷轴处于关闭状态，直接点击卷轴将其展开)
+            if self.appear_then_click(self.I_LOGIN_SCROOLL_CLOSE, interval=0.2):
+                logger.info('Click closed scroll to open it')
+                self.screenshot()
+                continue
             if self.appear(self.I_MAIN_GOTO_SHIKIGAMI_RECORDS, interval=0.2):
                 if confirm_timer.reached():
                     logger.info('Login to main confirm (shikigami records button appears)')

--- a/tasks/Restart/login.py
+++ b/tasks/Restart/login.py
@@ -50,7 +50,7 @@ class LoginHandler(BaseTask, RestartAssets, GameUiAssets):
                     self.screenshot()  # 点击后立即获取最新截图，确保后续状态检查准确
                     continue
             # 确认进入庭院(兜底：未检测到闲庭图片时，如果识别到卷轴处于关闭状态，直接点击卷轴将其展开)
-            if self.appear_then_click(self.I_LOGIN_SCROOLL_CLOSE, interval=0.2):
+            if self.appear_then_click(self.I_LOGIN_SCROOLL_CLOSE, interval=1):
                 logger.info('Click closed scroll to open it')
                 self.screenshot()
                 continue


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 通过点击已关闭的卷轴将其展开，确保当院子出现但未检测到空闲院子图像时，登录仍可继续进行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure login can proceed when the courtyard appears but the idle courtyard image is not detected by clicking closed scrolls to expand them.

</details>