### PR TITLE
Expand netherworld challenge ROI

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,48 @@
+# 单项任务测试流程
+
+适用于单独修复、验证 `tasks/<Task>` 下的一个功能，不启动完整调度器。
+
+## 1. 确认范围
+
+- 从错误目录和主日志确认配置实例、任务名、设备及失败时间。
+- 检查是否已有相同实例的任务进程，禁止两个进程同时操作同一设备。
+- 保留工作区现有修改，只处理当前任务相关文件。
+
+## 2. 定位问题
+
+- 按时间顺序检查 `log/error/<timestamp>/log.txt` 和截图。
+- 找到最后一次成功操作、未发生的预期操作及最终异常。
+- 对照任务代码、资源定义和识别阈值，先证明原因再修改。
+
+## 3. 最小修复
+
+- 只修改导致失败的逻辑或资源参数。
+- 资源由 JSON 等源文件生成时，同时更新源文件和运行时使用的生成文件。
+- 不顺手处理无关警告或格式化无关代码。
+
+## 4. 离线回归
+
+- 优先使用真实失败截图，按项目实际算法验证识别结果。
+- 记录命中坐标、匹配分数和阈值，断言分数高于阈值。
+- 执行相关 Python 语法检查、JSON 解析和 `git diff --check`。
+
+## 5. 完整运行
+
+使用项目自带的 `toolkit/python.exe`，直接运行指定任务：
+
+```powershell
+./toolkit/python.exe -c "from module.logger import logger; from module.ocr.rpc import ensure_ocr_server_started; from script import Script; ensure_ocr_server_started(); logger.set_file_logger('oas2', do_cleanup=False); ok=Script('oas2').run('Hunt'); print('TASK_RESULT=' + str(ok)); raise SystemExit(0 if ok else 2)"
+```
+
+运行时替换配置名 `oas2` 和任务名 `Hunt`。持续查看对应的 `log/<date>_<config>.txt`，直到任务结束，不以“成功启动”作为测试通过。
+
+## 6. 通过标准
+
+必须同时满足：
+
+- 修复涉及的目标操作在真实日志中成功执行。
+- 任务进入核心流程并产生明确成功结果，例如 `Battle win`。
+- 命令返回 `TASK_RESULT=True` 和退出码 `0`。
+- `log/error` 没有生成新的错误目录。
+
+若失败，保存新的错误目录和日志，重新定位后再运行；对于会消耗每日次数或资源的任务，避免无依据地连续重试。

--- a/tasks/Hunt/assets.py
+++ b/tasks/Hunt/assets.py
@@ -37,8 +37,7 @@ class HuntAssets:
 	# 点击阴界之门 
 	I_NW = RuleImage(roi_front=(1060,602,100,100), roi_back=(1060,602,100,100), threshold=0.8, method="Template matching", file="./tasks/Hunt/netherworld/netherworld_nw.png")
 	# 点击挑战 
-	I_NW_CHALLAGE = RuleImage(roi_front=(306,590,171,63), roi_back=(306,590,171,63), threshold=0.8, method="Template matching", file="./tasks/Hunt/netherworld/netherworld_nw_challage.png")
+	I_NW_CHALLAGE = RuleImage(roi_front=(306,590,171,63), roi_back=(300,584,190,75), threshold=0.8, method="Template matching", file="./tasks/Hunt/netherworld/netherworld_nw_challage.png")
 	# 今日已挑战 
 	I_NW_DONE = RuleImage(roi_front=(308,600,156,41), roi_back=(308,600,156,41), threshold=0.9, method="Template matching", file="./tasks/Hunt/netherworld/netherworld_nw_done.png")
-
 

--- a/tasks/Hunt/netherworld/image.json
+++ b/tasks/Hunt/netherworld/image.json
@@ -12,7 +12,7 @@
     "itemName": "nw_challage",
     "imageName": "netherworld_nw_challage.png",
     "roiFront": "306,590,171,63",
-    "roiBack": "306,590,171,63",
+    "roiBack": "300,584,190,75",
     "method": "Template matching",
     "threshold": 0.8,
     "description": "点击挑战"


### PR DESCRIPTION
Split from leovefy/cobra.

This PR contains a single commit: 95d0c81e.
Base: runhey/dev.

## Summary by Sourcery

调整冥界狩猎挑战检测参数，并记录推荐的单任务调试与测试工作流程。

Bug Fixes:
- 通过扩展图像匹配的 ROI（感兴趣区域），提升冥界挑战按钮的识别效果。

Documentation:
- 新增 AGENT.md，描述在不运行完整调度器的情况下，隔离、修复并验证单个任务失败的具体流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust netherworld hunt challenge detection parameters and document the recommended single-task debugging and testing workflow.

Bug Fixes:
- Improve the netherworld challenge button recognition by expanding its image matching ROI.

Documentation:
- Add AGENT.md describing the process for isolating, fixing, and validating individual task failures without running the full scheduler.

</details>