### PR TITLE
Handle active Abyss Shadows map on Shenshe entry

### DIFF
--- a/tasks/AbyssShadows/assets.py
+++ b/tasks/AbyssShadows/assets.py
@@ -61,7 +61,7 @@ class AbyssShadowsAssets:
 	# 式神录 
 	I_ABYSS_SHIKI = RuleImage(roi_front=(1199,462,47,53), roi_back=(1199,462,47,53), threshold=0.8, method="Template matching", file="./tasks/AbyssShadows/res/res_abyss_shiki.png")
 	# 狭间暗域 
-	I_ABYSS_SHADOWS = RuleImage(roi_front=(711,489,107,38), roi_back=(711,479,107,48), threshold=0.8, method="Template matching", file="./tasks/AbyssShadows/res/res_abyss_shadows.png")
+	I_ABYSS_SHADOWS = RuleImage(roi_front=(711,489,107,38), roi_back=(700,470,140,70), threshold=0.8, method="Template matching", file="./tasks/AbyssShadows/res/res_abyss_shadows.png")
 	# 开启狭间暗域 
 	I_OPEN_ABYSS_SHADOWS = RuleImage(roi_front=(1133,602,74,58), roi_back=(1133,602,74,58), threshold=0.8, method="Template matching", file="./tasks/AbyssShadows/res/res_open_abyss_shadows.png")
 	# 战报页面 
@@ -101,5 +101,4 @@ class AbyssShadowsAssets:
 	# Swipe Rule Assets
 	# 滑到狭间 
 	S_TO_ABBSY_SHADOWS = RuleSwipe(roi_front=(752,395,62,66), roi_back=(758,193,62,48), mode="default", name="to_abbsy_shadows")
-
 

--- a/tasks/AbyssShadows/res/image.json
+++ b/tasks/AbyssShadows/res/image.json
@@ -75,7 +75,7 @@
     "itemName": "abyss_shadows",
     "imageName": "res_abyss_shadows.png",
     "roiFront": "711,489,107,38",
-    "roiBack": "711,479,107,48",
+    "roiBack": "700,470,140,70",
     "method": "Template matching",
     "threshold": 0.8,
     "description": "狭间暗域"

--- a/tasks/AbyssShadows/script_task.py
+++ b/tasks/AbyssShadows/script_task.py
@@ -317,6 +317,10 @@ class ScriptTask(GeneralBattle, GameUi, SwitchSoul, AbyssShadowsAssets):
         
         while 1:
             self.screenshot()
+            # Entering Shenshe can resume an active Abyss Shadows map directly.
+            if self.appear(self.I_ABYSS_NAVIGATION):
+                logger.info("Already in abyss_shadows")
+                break
             # 进入神社
             if self.appear_then_click(self.I_RYOU_SHENSHE,interval=1):
                 logger.info("Enter Shenshe")


### PR DESCRIPTION
Split from leovefy/cobra.

This PR contains a single commit: 1bb93508.
Base: runhey/dev.

## Summary by Sourcery

在进入神社时处理已经处于激活状态的深渊暗影运行，并调整深渊暗影地图界面的检测方式。

Bug 修复：
- 在进入神社后，如果深渊暗影导航界面已处于激活状态，则进行检测并提前短路以避免重复操作。

增强：
- 扩展深渊暗影地图的检测区域，以更稳健地识别地图处于激活状态的情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle the case where entering Shenshe resumes an already active Abyss Shadows run and adjust detection of the Abyss Shadows map UI.

Bug Fixes:
- Detect and short-circuit when the Abyss Shadows navigation UI is already active after entering Shenshe to avoid redundant actions.

Enhancements:
- Expand the Abyss Shadows map detection region to more robustly recognize the active map state.

</details>