### PR TITLE
Handle additional Demon Retreat entry states

### DIFF
--- a/tasks/DemonRetreat/script_task.py
+++ b/tasks/DemonRetreat/script_task.py
@@ -123,7 +123,9 @@ class ScriptTask(GameUi, GeneralBattle, SwitchSoul, DemonRetreatAssets, AbyssSha
             # 确保不离开退治
             if self.appear_then_click(self.I_QUIT_BACK, interval=1):
                 pass
-            if self.appear(self.I_HUNT_CHECK):
+            if (self.appear(self.I_HUNT_CHECK)
+                    or self.appear(self.I_DEMON_GATHER)
+                    or self.is_in_prepare(False)):
                 if self.appear_then_click(self.I_QUIT_BACK, interval=1):
                     pass
                 logger.info("Enter demon_retreat success")


### PR DESCRIPTION
Split from leovefy/cobra.

This PR contains a single commit: 1dc42d90.
Base: runhey/dev.

## Summary by Sourcery

错误修复：
- 在记录成功之前，将猎杀检查、恶魔聚集和准备状态视为处于“恶魔撤退”（Demon Retreat）的有效指示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Treat hunt check, demon gather, and preparation states as valid indications of being in Demon Retreat before logging success.

</details>