### PR TITLE
Fix HeroTest OCR mode for art war card plus

### DIFF
--- a/tasks/HeroTest/as/ocr.json
+++ b/tasks/HeroTest/as/ocr.json
@@ -21,7 +21,7 @@
     "itemName": "art_war_card_plus",
     "roiFront": "916,25,90,29",
     "roiBack": "916,25,90,29",
-    "mode": "SINGLE",
+    "mode": "Digit",
     "method": "Default",
     "keyword": "",
     "description": "兵道帖机密"

--- a/tasks/HeroTest/assets.py
+++ b/tasks/HeroTest/assets.py
@@ -107,8 +107,7 @@ class HeroTestAssets:
 	# 兵藏秘境兵道帖 
 	O_ART_WAR_CARD = RuleOcr(roi=(712,21,98,36), area=(712,21,98,36), mode="DigitCounter", method="Default", keyword="", name="art_war_card")
 	# 兵道帖机密 
-	O_ART_WAR_CARD_PLUS = RuleOcr(roi=(916,25,90,29), area=(916,25,90,29), mode="SINGLE", method="Default", keyword="", name="art_war_card_plus")
+	O_ART_WAR_CARD_PLUS = RuleOcr(roi=(916,25,90,29), area=(916,25,90,29), mode="Digit", method="Default", keyword="", name="art_war_card_plus")
 	# 挑战按钮 
 	O_FIRE = RuleOcr(roi=(1130,585,92,55), area=(1126,576,100,99), mode="Single", method="Default", keyword="挑战", name="fire")
-
 

--- a/tasks/HeroTest/script_task.py
+++ b/tasks/HeroTest/script_task.py
@@ -209,7 +209,6 @@ class ScriptTask(GameUi, GeneralBattle, HeroTestAssets, SwitchSoul):
             logger.info("Art war card is enough")
             return True
         cu = self.O_ART_WAR_CARD_PLUS.ocr(image=self.device.image)
-        cu = 0 if cu == '' else int(cu)
         if cu >= 1:
             logger.info("Art war card is not enough, but plus card is enough")
             return True


### PR DESCRIPTION
Split from leovefy/cobra.

This PR contains a single commit: 29720db0.
Base: runhey/dev.

## Summary by Sourcery

Bug Fixes:
- 修正艺术战争加成卡的 OCR 模式和数值处理方式，以便正确识别卡牌数量。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the OCR mode and value handling for the art war plus card so card counts are properly recognized.

</details>