### PR TITLE
Use ASCII JSON responses for proxy compatibility

### DIFF
--- a/module/server/app.py
+++ b/module/server/app.py
@@ -2,6 +2,7 @@
 # @author runhey
 # github https://github.com/runhey
 from pathlib import Path
+import json
 
 from contextlib import asynccontextmanager
 
@@ -20,6 +21,19 @@ from module.server.main_manager import mm
 from starlette.staticfiles import StaticFiles
 
 
+class ASCIIJSONResponse(JSONResponse):
+    """Serialize non-ASCII characters as ``\\uXXXX`` for proxy compatibility."""
+
+    def render(self, content) -> bytes:
+        return json.dumps(
+            content,
+            ensure_ascii=True,
+            allow_nan=False,
+            indent=None,
+            separators=(",", ":"),
+        ).encode("utf-8")
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     await on_startup()
@@ -31,6 +45,7 @@ app = FastAPI(
     description='OAS web service',
     version='0.0.0',
     lifespan=lifespan,
+    default_response_class=ASCIIJSONResponse,
 )
 
 app.add_middleware(
@@ -70,7 +85,7 @@ async def global_exception_handler(request: Request, exc: Exception):
 
     message = ', '.join(str(arg) for arg in exc.args) if exc.args else str(exc)
 
-    return JSONResponse(
+    return ASCIIJSONResponse(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         content={
             'message': message

--- a/module/server/app.py
+++ b/module/server/app.py
@@ -1,16 +1,17 @@
 # This Python file uses the following encoding: utf-8
 # @author runhey
 # github https://github.com/runhey
-from pathlib import Path
-import json
-
-from contextlib import asynccontextmanager
-
 import argparse
-from starlette import status
-from starlette.responses import JSONResponse
+import json
+from contextlib import asynccontextmanager
+from pathlib import Path
+
 from fastapi import FastAPI, Request
+from fastapi.encoders import jsonable_encoder
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from starlette import status
+from starlette.staticfiles import StaticFiles
 
 from module.logger import logger
 from module.server.home_router import home_app
@@ -18,15 +19,15 @@ from module.server.script_router import script_app
 from module.server.tool_router import tool_app
 from module.server.setting import State
 from module.server.main_manager import mm
-from starlette.staticfiles import StaticFiles
 
 
 class ASCIIJSONResponse(JSONResponse):
     """Serialize non-ASCII characters as ``\\uXXXX`` for proxy compatibility."""
 
     def render(self, content) -> bytes:
+        encoded_content = jsonable_encoder(content)
         return json.dumps(
-            content,
+            encoded_content,
             ensure_ascii=True,
             allow_nan=False,
             indent=None,


### PR DESCRIPTION
Split from leovefy/cobra.

This PR contains a single commit: 28a71a98.
Base: runhey/dev.

## Summary by Sourcery

将 FastAPI 应用配置为在所有响应和内部错误处理中使用仅包含 ASCII 字符的 JSON 响应类，以提升与代理的兼容性。

New Features:
- 引入自定义的 `ASCIIJSONResponse` 类，以仅使用 ASCII 字符序列化 JSON，从而兼容特定代理。

Enhancements:
- 将 FastAPI 应用的默认响应类和全局异常处理器设置为使用新的 `ASCIIJSONResponse`，以确保输出的 JSON 一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Configure the FastAPI application to use an ASCII-only JSON response class for all responses and internal error handling to improve proxy compatibility.

New Features:
- Introduce a custom ASCIIJSONResponse class that serializes JSON with ASCII-only characters for compatibility with certain proxies.

Enhancements:
- Set the FastAPI app's default response class and global exception handler to use the new ASCIIJSONResponse for consistent JSON output.

</details>