### PR TITLE
Handle invalid art war card OCR values

### DIFF
--- a/tasks/HeroTest/script_task.py
+++ b/tasks/HeroTest/script_task.py
@@ -209,7 +209,11 @@ class ScriptTask(GameUi, GeneralBattle, HeroTestAssets, SwitchSoul):
             logger.info("Art war card is enough")
             return True
         cu = self.O_ART_WAR_CARD_PLUS.ocr(image=self.device.image)
-        cu = 0 if cu == '' else int(cu)
+        try:
+            cu = int(cu)
+        except (TypeError, ValueError) as e:
+            logger.warning(f"Unexpected art war card plus OCR result: {cu!r}, {e}")
+            cu = 0
         if cu >= 1:
             logger.info("Art war card is not enough, but plus card is enough")
             return True


### PR DESCRIPTION
Split from leovefy/cobra.

This PR contains a single commit: d1c9dc32.
Base: runhey/dev.

## Summary by Sourcery

Bug Fixes:
- 当 OCR 结果缺失或不是有效整数时，将默认艺术战争卡和 OCR 值设为零，并记录一条警告日志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Default art war card plus OCR value to zero and log a warning when the OCR result is missing or not a valid integer.

</details>