### PR TITLE
fix(Exploration): 每次仅开始运行探索任务时放置狗粮

### DIFF
--- a/tasks/Exploration/base.py
+++ b/tasks/Exploration/base.py
@@ -198,7 +198,7 @@ class BaseExploration(GameUi, GeneralBattle, GeneralRoom, GeneralInvite, Replace
             logger.warning('Opening settings failed due to now in battle')
             return
         cu, res, total = self.O_E_ALTERNATE_NUMBER.ocr(self.device.image)
-        if cu >= 10:
+        if cu >= 40:
             logger.info("Alternate number is enough")
             self.ui_click_until_disappear(self.I_E_SURE_BUTTON)
             return

--- a/tasks/Exploration/solo.py
+++ b/tasks/Exploration/solo.py
@@ -15,6 +15,7 @@ from tasks.Exploration.config import ChooseRarity, AutoRotate, UserStatus, Explo
 class SoloExploration(BaseExploration):
     INVITE_FLAG_OFF = (157, 109, 83)
     INVITE_FLAG_ON = (227, 193, 153)
+    explore_init = False
 
     @cached_property
     def _invite_config(self) -> InviteConfig:
@@ -29,7 +30,6 @@ class SoloExploration(BaseExploration):
 
     def run_solo(self):
         logger.hr('solo')
-        explore_init = False
         search_fail_cnt = 0
 
         while 1:
@@ -48,22 +48,20 @@ class SoloExploration(BaseExploration):
                 if self.check_exit():
                     break
                 self.open_expect_level()
-                explore_init = False
                 continue
             #
             elif scene == Scene.ENTRANCE:
                 if self.check_exit():
                     break
                 self.ui_click(self.I_E_EXPLORATION_CLICK, stop=self.I_E_SETTINGS_BUTTON)
-                explore_init = False
                 continue
             #
             elif scene == Scene.MAIN:
-                if not explore_init:
-                    self.ui_click(self.I_E_AUTO_ROTATE_OFF, stop=self.I_E_AUTO_ROTATE_ON)
+                if not self.explore_init:
                     if self._config.exploration_config.auto_rotate == AutoRotate.yes:
                         self.enter_settings_and_do_operations()
-                    explore_init = True
+                    self.ui_click(self.I_E_AUTO_ROTATE_OFF, stop=self.I_E_AUTO_ROTATE_ON)
+                    self.explore_init = True
                     continue
                 # 小纸人
                 if self.appear(self.I_BATTLE_REWARD):
@@ -100,7 +98,6 @@ class SoloExploration(BaseExploration):
 
     def run_leader(self):
         logger.hr('leader')
-        explore_init = False
         search_fail_cnt = 0
         friend_leave_timer = Timer(10)
 
@@ -139,7 +136,7 @@ class SoloExploration(BaseExploration):
                     # 可以加一下，清空第一次 explore_init
                     continue
                 self.open_expect_level()
-                explore_init = False
+                # explore_init = False
                 continue
 
             # 邀请好友, 非常有可能是后面邀请好友，然后直接跳到组队了
@@ -179,12 +176,12 @@ class SoloExploration(BaseExploration):
                     break
             ##
             elif scene == Scene.MAIN:
-                if not explore_init:
-                    self.ui_click(self.I_E_AUTO_ROTATE_OFF, stop=self.I_E_AUTO_ROTATE_ON)
+                if not self.explore_init:
                     if self._config.exploration_config.auto_rotate == AutoRotate.yes:
                         self.enter_settings_and_do_operations()
+                    self.ui_click(self.I_E_AUTO_ROTATE_OFF, stop=self.I_E_AUTO_ROTATE_ON)
                     friend_leave_timer = Timer(10)
-                    explore_init = True
+                    self.explore_init = True
                     continue
                 # 小纸人
                 if self.appear(self.I_BATTLE_REWARD):
@@ -235,7 +232,6 @@ class SoloExploration(BaseExploration):
 
     def run_member(self):
         logger.hr('member')
-        explore_init = False
         wait_timer = Timer(50)
         friend_leave_timer = Timer(10)
 
@@ -260,7 +256,6 @@ class SoloExploration(BaseExploration):
                     logger.warning('Wait timer reached')
                     break
 
-                explore_init = False
                 continue
             #
             elif scene == Scene.ENTRANCE:
@@ -270,11 +265,11 @@ class SoloExploration(BaseExploration):
                 continue
             #
             elif scene == Scene.MAIN:
-                if not explore_init:
-                    self.ui_click(self.I_E_AUTO_ROTATE_OFF, stop=self.I_E_AUTO_ROTATE_ON)
+                if not self.explore_init:
                     if self._config.exploration_config.auto_rotate == AutoRotate.yes:
                         self.enter_settings_and_do_operations()
-                    explore_init = True
+                    self.ui_click(self.I_E_AUTO_ROTATE_OFF, stop=self.I_E_AUTO_ROTATE_ON)
+                    self.explore_init = True
                     continue
                 # 小纸人
                 if self.appear(self.I_BATTLE_REWARD):


### PR DESCRIPTION
- 重构 explore_init 改为全局
- 每次仅开始运行探索任务时放置狗粮
- 提高候补狗粮数量
- 优化候补开关点击时机

## Summary by Sourcery

让单人、队长和队员的探索运行共用一个初始化标志，使每次探索运行的初始化只执行一次，并基于更新后的替代物品阈值来调整探索设置。

改进内容：
- 将探索初始化标志提升为实例属性，在单人、队长和队员流程中共用，以避免重复的初始化操作。
- 在确认前检查探索设置时，将替代物品（狗粮）阈值从 10 提升到 40。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make solo, leader, and member exploration runs use a shared initialization flag so exploration setup happens only once per run, and adjust exploration settings based on updated alternate item thresholds.

Enhancements:
- Promote the exploration initialization flag to an instance attribute used across solo, leader, and member flows to avoid redundant setup actions.
- Increase the alternate item (狗粮) threshold from 10 to 40 when checking exploration settings before confirming.

</details>