### PR TITLE
修复真蛇次数计算逻辑错误

### DIFF
--- a/tasks/TrueOrochi/script_task.py
+++ b/tasks/TrueOrochi/script_task.py
@@ -197,8 +197,8 @@ class ScriptTask(OrochiScriptTask, TrueOrochiAssets):
             logger.info('Battle skipped or not found True Orochi')
             next_run = now + self.config.true_orochi.scheduler.failure_interval
         next_run_year, next_run_week_number, next_run_weekday = next_run.isocalendar()
-        # 如果下次运行的时间是下一周，那么就重置成功次数，加入跨年周数重置判断
-        if (now_year, now_week_number) != (next_run_year, next_run_week_number):
+        # 如果下次运行的时间是下一周，那么就重置成功次数
+        if now_week_number != next_run_week_number:
             logger.info('Reset current_success')
             self.config.true_orochi.true_orochi_config.current_success = 0
 

--- a/tasks/TrueOrochi/script_task.py
+++ b/tasks/TrueOrochi/script_task.py
@@ -181,26 +181,27 @@ class ScriptTask(OrochiScriptTask, TrueOrochiAssets):
     def check_times(self, battle: bool):
         """
         后续的次数和时间设置
-        :param battle:
+        :param battle: 本次是否挑战了真蛇
         :param current_success: 这周的成功次数
         :return:
         """
         now = datetime.now()
         now_year, now_week_number, now_weekday = now.isocalendar()
         if battle:
-            next_run = now + self.config.true_orochi.scheduler.success_interval
-        else:
-            next_run = now + self.config.true_orochi.scheduler.failure_interval
-        next_run_year, next_run_week_number, next_run_weekday = next_run.isocalendar()
-        # 如果下次运行的时间是下一周，那么就重置成功次数
-        if now_week_number != next_run_week_number:
-            logger.info('Reset current_success')
-            self.config.true_orochi.true_orochi_config.current_success = 0
-        else:
-            # 如果不是下一周，那么就加一
+            # 只有真正打过才加一次数
             logger.info('Add current_success by 1')
             self.config.true_orochi.true_orochi_config.current_success += 1
             self.config.true_orochi.true_orochi_config.current_success = min(2, self.config.true_orochi.true_orochi_config.current_success)
+            next_run = now + self.config.true_orochi.scheduler.success_interval
+        else:
+            logger.info('Battle skipped or not found True Orochi')
+            next_run = now + self.config.true_orochi.scheduler.failure_interval
+        next_run_year, next_run_week_number, next_run_weekday = next_run.isocalendar()
+        # 如果下次运行的时间是下一周，那么就重置成功次数，加入跨年周数重置判断
+        if (now_year, now_week_number) != (next_run_year, next_run_week_number):
+            logger.info('Reset current_success')
+            self.config.true_orochi.true_orochi_config.current_success = 0
+
         self.config.save()
         self.set_next_run(task='TrueOrochi', target=next_run)
         # self.set_next_run('TrueOrochi', finish=True, success=True)


### PR DESCRIPTION
## Summary by Sourcery

修复 True Orochi 每周成功计数的处理和调度逻辑。

Bug 修复：
- 只有在实际进行战斗时才递增 True Orochi 每周成功计数，而不是在每次未跨周的运行时都递增。
- 当下一次计划运行落在不同的日历周（包括跨年份的情况）时，正确重置 True Orochi 成功计数。

增强：
- 在 True Orochi 战斗处理和成功计数更新周围增加日志，并澄清战斗参数的文档说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix True Orochi weekly success counter handling and scheduling logic.

Bug Fixes:
- Only increment the True Orochi weekly success counter when a battle actually occurs instead of on every non-week-crossing run.
- Correctly reset the True Orochi success counter when the next scheduled run falls in a different calendar week, including across year boundaries.

Enhancements:
- Add logging around True Orochi battle handling and success counter updates, and clarify the battle parameter documentation.

</details>