### PR TITLE
fix: 修复契灵创建队伍弹窗卡死

### DIFF
--- a/tasks/BondlingFairyland/general_invite.py
+++ b/tasks/BondlingFairyland/general_invite.py
@@ -464,12 +464,34 @@ class GeneralInvite(BaseTask, BondlingFairylandAssets, GeneralInviteAssets):
         if not self.appear(self.I_GI_SURE, interval=1.5):
             return False
 
+        # This dialog may be replaced by the bondling create-team dialog as
+        # soon as confirmation is clicked.  Do not let either loop below wait
+        # forever for controls from the previous dialog.
+        handle_timer = Timer(8).start()
+
+        def invite_dialog_changed() -> bool:
+            if self.appear(self.I_CREATE_TEAM):
+                logger.info('Create-team dialog appeared while handling default invite')
+                return True
+            if self.appear(self.I_GI_IN_ROOM) or self.is_in_room(is_screenshot=False):
+                logger.info('Room entered while handling default invite')
+                return True
+            if self.appear(self.I_BALL_HELP) or self.appear(self.I_BALL_AREA):
+                logger.info('Left default-invite dialog')
+                return True
+            return False
+
         if default_invite:
             # 有可能是挑战失败的
             if self.appear(self.I_I_DEFAULT) or self.appear(self.I_I_NO_DEFAULT):
                 logger.info('Click default invite')
                 while 1:
                     self.screenshot()
+                    if invite_dialog_changed():
+                        return False
+                    if handle_timer.reached():
+                        logger.warning('Default-invite checkbox handling timed out')
+                        return False
                     if self.appear(self.I_I_DEFAULT):
                         break
                     if self.appear_then_click(self.I_I_NO_DEFAULT, interval=1):
@@ -477,6 +499,11 @@ class GeneralInvite(BaseTask, BondlingFairylandAssets, GeneralInviteAssets):
         # 点击确认
         while 1:
             self.screenshot()
+            if invite_dialog_changed():
+                return False
+            if handle_timer.reached():
+                logger.warning('Default-invite confirmation handling timed out')
+                return False
             if not self.appear(self.I_GI_SURE):
                 break
             if self.appear_then_click(self.I_GI_SURE, interval=1):

--- a/tasks/BondlingFairyland/script_task.py
+++ b/tasks/BondlingFairyland/script_task.py
@@ -109,8 +109,9 @@ class ScriptTask(GameUi, GeneralInvite, GeneralRoom, BondlingBattle, SwitchSoul,
                     # 某些活动的时候出现 “选择共鸣的阴阳师”
                     if self.appear_then_click(self.I_UI_CONFIRM, interval=1):
                         continue
-                    if self.check_and_invite(True):
-                        continue
+                    # The post-battle/default-invite dialog can transition directly
+                    # to the create-team dialog.  Handle that dialog first so
+                    # check_and_invite() cannot keep waiting for stale invite UI.
                     if self.appear(self.I_CREATE_TEAM, interval=1):
                         self.ensure_private()
                         if self.appear_then_click(self.I_CREATE_TEAM, interval=2):
@@ -123,6 +124,8 @@ class ScriptTask(GameUi, GeneralInvite, GeneralRoom, BondlingBattle, SwitchSoul,
                                     return True
                                 if self.appear(self.I_BALL_HELP) or self.appear(self.I_CREATE_TEAM):
                                     break
+                        continue
+                    if self.check_and_invite(True):
                         continue
                     # 求援
                     if self.appear(self.I_BALL_AREA, interval=1):


### PR DESCRIPTION
## 修改内容

- 在处理“默认邀请”流程前，优先识别并处理契灵“创建队伍”弹窗。
- 默认邀请处理期间，如果界面已经切换到创建队伍、组队房间、求援页或契灵区域页，立即退出旧弹窗流程并交回外层状态机处理。
- 为默认邀请勾选和确认循环增加 8 秒超时保护，避免无限等待。

## 问题原因

房主点击“求援”并确认后，游戏可能直接切换到“创建队伍”弹窗。原来的 `check_and_invite()` 仍会继续等待上一个“默认邀请”弹窗中的控件，导致外层循环没有机会处理 `I_CREATE_TEAM`，最终在等待 60 秒后触发 `GameStuckError: Wait too long`。

## 修复效果

当游戏从默认邀请弹窗切换到创建队伍弹窗时，脚本可以及时识别状态变化，继续设置私密房间并创建队伍，不再长时间卡住。

## 验证

- `python -m py_compile tasks/BondlingFairyland/script_task.py tasks/BondlingFairyland/general_invite.py`
- `git diff --check`
