### PR TITLE
fix(Hyakkiyakou_Recall): 调整回归活动时百鬼邀请的标签ROI坐标

### DIFF
--- a/tasks/Hyakkiyakou/assets.py
+++ b/tasks/Hyakkiyakou/assets.py
@@ -157,13 +157,13 @@ class HyakkiyakouAssets:
 	# description 
 	I_FRIEND_REMOTE_2 = RuleImage(roi_front=(440,122,89,56), roi_back=(440,122,89,56), threshold=0.8, method="Template matching", file="./tasks/Hyakkiyakou/hya/hya_friend_remote_2.png")
 	# 回归活动使用 
-	I_FRIEND_SAME_1_RECALL = RuleImage(roi_front=(167,123,106,62), roi_back=(154,105,132,94), threshold=0.8, method="Template matching", file="./tasks/Hyakkiyakou/hya/hya_friend_same_1.png")
+	I_FRIEND_SAME_1_RECALL = RuleImage(roi_front=(137,123,106,62), roi_back=(124,105,132,94), threshold=0.8, method="Template matching", file="./tasks/Hyakkiyakou/hya/hya_friend_same_1.png")
 	# 回归活动使用 
-	I_FRIEND_REMOTE_1_RECALL = RuleImage(roi_front=(288,123,106,56), roi_back=(269,106,159,91), threshold=0.8, method="Template matching", file="./tasks/Hyakkiyakou/hya/hya_friend_remote_1.png")
+	I_FRIEND_REMOTE_1_RECALL = RuleImage(roi_front=(218,123,106,56), roi_back=(199,106,159,91), threshold=0.8, method="Template matching", file="./tasks/Hyakkiyakou/hya/hya_friend_remote_1.png")
 	# 回归活动使用 
-	I_FRIEND_SAME_2_RECALL = RuleImage(roi_front=(168,126,100,60), roi_back=(152,112,133,80), threshold=0.8, method="Template matching", file="./tasks/Hyakkiyakou/hya/hya_friend_same_2.png")
+	I_FRIEND_SAME_2_RECALL = RuleImage(roi_front=(138,126,100,60), roi_back=(122,112,133,80), threshold=0.8, method="Template matching", file="./tasks/Hyakkiyakou/hya/hya_friend_same_2.png")
 	# 回归活动使用 
-	I_FRIEND_REMOTE_2_RECALL = RuleImage(roi_front=(296,122,100,56), roi_back=(278,115,131,81), threshold=0.8, method="Template matching", file="./tasks/Hyakkiyakou/hya/hya_friend_remote_2.png")
+	I_FRIEND_REMOTE_2_RECALL = RuleImage(roi_front=(226,122,100,56), roi_back=(208,115,131,81), threshold=0.8, method="Template matching", file="./tasks/Hyakkiyakou/hya/hya_friend_remote_2.png")
 	# 寮 
 	I_FRIEND_RYOU_1 = RuleImage(roi_front=(537,126,80,45), roi_back=(537,126,80,45), threshold=0.8, method="Template matching", file="./tasks/Hyakkiyakou/hya/hya_friend_ryou_1.png")
 	# description 

--- a/tasks/Hyakkiyakou/hya/image5.json
+++ b/tasks/Hyakkiyakou/hya/image5.json
@@ -38,8 +38,8 @@
   {
     "itemName": "friend_same_1_recall",
     "imageName": "hya_friend_same_1.png",
-    "roiFront": "167,123,106,62",
-    "roiBack": "154,105,132,94",
+    "roiFront": "137,123,106,62",
+    "roiBack": "124,105,132,94",
     "method": "Template matching",
     "threshold": 0.8,
     "description": "回归活动使用"
@@ -47,8 +47,8 @@
   {
     "itemName": "friend_remote_1_recall",
     "imageName": "hya_friend_remote_1.png",
-    "roiFront": "288,123,106,56",
-    "roiBack": "269,106,159,91",
+    "roiFront": "218,123,106,56",
+    "roiBack": "199,106,159,91",
     "method": "Template matching",
     "threshold": 0.8,
     "description": "回归活动使用"
@@ -56,8 +56,8 @@
   {
     "itemName": "friend_same_2_recall",
     "imageName": "hya_friend_same_2.png",
-    "roiFront": "168,126,100,60",
-    "roiBack": "152,112,133,80",
+    "roiFront": "138,126,100,60",
+    "roiBack": "122,112,133,80",
     "method": "Template matching",
     "threshold": 0.8,
     "description": "回归活动使用"
@@ -65,8 +65,8 @@
   {
     "itemName": "friend_remote_2_recall",
     "imageName": "hya_friend_remote_2.png",
-    "roiFront": "296,122,100,56",
-    "roiBack": "278,115,131,81",
+    "roiFront": "226,122,100,56",
+    "roiBack": "208,115,131,81",
     "method": "Template matching",
     "threshold": 0.8,
     "description": "回归活动使用"


### PR DESCRIPTION
新增寮友标签后坐标整体左移

## Summary by Sourcery

Bug Fixes:
- 修正召回活动好友图片的 ROI 坐标，以便在新的左移布局下，模板匹配功能正常工作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct ROI coordinates for recall activity friend images so template matching works with the new left-shifted layout.

</details>