### PR TITLE
Fix(SoulsTidy)解决御魂奉纳点入好友界面卡住的问题

### DIFF
--- a/tasks/SoulsTidy/script_task.py
+++ b/tasks/SoulsTidy/script_task.py
@@ -111,8 +111,8 @@ class ScriptTask(GameUi, SoulsTidyAssets):
                     break
                 if self.click(self.I_ST_ABANDONED_SELECTED, interval=1.5):
                     # 防止点入好友界面
-                    self.wait_until_appear_then_click(self.I_UI_BACK_RED, wait_time=1)
-                    continue
+                    if self.wait_until_appear(self.I_UI_BACK_RED, wait_time=1):
+                        self.ui_click_until_disappear(self.I_UI_BACK_RED, interval=1)
             # 确保是按照等级来排序的
             while 1:
                 self.screenshot()

--- a/tasks/SoulsTidy/script_task.py
+++ b/tasks/SoulsTidy/script_task.py
@@ -109,6 +109,9 @@ class ScriptTask(GameUi, SoulsTidyAssets):
                 self.screenshot()
                 if self.appear(self.I_ST_ABANDONED_SELECTED):
                     break
+                # 防止点入好友界面
+                if self.appear_then_click(self.I_UI_BACK_RED, interval=0.5):
+                    continue
                 self.click(self.I_ST_ABANDONED_SELECTED, interval=1.5)
             # 确保是按照等级来排序的
             while 1:

--- a/tasks/SoulsTidy/script_task.py
+++ b/tasks/SoulsTidy/script_task.py
@@ -109,10 +109,10 @@ class ScriptTask(GameUi, SoulsTidyAssets):
                 self.screenshot()
                 if self.appear(self.I_ST_ABANDONED_SELECTED):
                     break
-                # 防止点入好友界面
-                if self.appear_then_click(self.I_UI_BACK_RED, interval=0.5):
+                if self.click(self.I_ST_ABANDONED_SELECTED, interval=1.5):
+                    # 防止点入好友界面
+                    self.wait_until_appear_then_click(self.I_UI_BACK_RED, wait_time=1)
                     continue
-                self.click(self.I_ST_ABANDONED_SELECTED, interval=1.5)
             # 确保是按照等级来排序的
             while 1:
                 self.screenshot()


### PR DESCRIPTION
<img width="225" height="129" alt="QQ_1784474326238" src="https://github.com/user-attachments/assets/c7f3ba6e-04bf-454a-b5a5-34ceecffcc11" />

## Summary by Sourcery

Bug Fixes:
- 在 `greed_maneki` 任务中添加保护措施，用于在选择废弃物品后检测好友界面是否出现，并在出现时退出该界面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Add a safeguard in the greed_maneki task to detect and exit the friend UI when it appears after selecting abandoned items.

</details>