### PR TITLE
fix(AreaBoss_Ultra): 增加等待保证进入鬼王界面

### DIFF
--- a/tasks/AreaBoss/script_task.py
+++ b/tasks/AreaBoss/script_task.py
@@ -182,6 +182,8 @@ class ScriptTask(GeneralBattle, GameUi, SwitchSoul, AreaBossAssets):
         return self.run_general_battle(self.config.area_boss.general_battle)
 
     def setup_ultra(self) -> bool:
+        # 确定进入鬼王界面
+        self.wait_until_appear(self.I_AB_CLOSE_RED)
         # 尝试切换
         if not self.get_difficulty():
             # 如果可以切换，直接切换


### PR DESCRIPTION
有时候鬼王界面开启太慢会让get_difficulty()直接运行导致后面都跑错，实际进入普通鬼王也不会切换到极

## Summary by Sourcery

Bug Fixes:
- 防止在鬼王界面完全打开之前运行 `get_difficulty()`，以避免在界面加载较慢时出现错误的战斗流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent get_difficulty() from running before the鬼王 interface is fully opened, avoiding incorrect battle flow when the UI loads slowly.

</details>