### PR TITLE
fix(WeeklyTrifles): 调整分享按钮图像识别区域坐标

### DIFF
--- a/tasks/WeeklyTrifles/area_boss/image.json
+++ b/tasks/WeeklyTrifles/area_boss/image.json
@@ -20,8 +20,8 @@
   {
     "itemName": "wt_share_ab",
     "imageName": "area_boss_wt_share_ab.png",
-    "roiFront": "1183,308,45,39",
-    "roiBack": "1183,308,45,39",
+    "roiFront": "1187,273,45,39",
+    "roiBack": "1176,90,76,326",
     "method": "Template matching",
     "threshold": 0.8,
     "description": "地鬼分享"

--- a/tasks/WeeklyTrifles/assets.py
+++ b/tasks/WeeklyTrifles/assets.py
@@ -21,7 +21,7 @@ class WeeklyTriflesAssets:
 	# 今天一个都没有打 
 	I_WT_NO_DAY = RuleImage(roi_front=(167,360,72,69), roi_back=(167,360,72,69), threshold=0.8, method="Template matching", file="./tasks/WeeklyTrifles/area_boss/area_boss_wt_no_day.png")
 	# 地鬼分享 
-	I_WT_SHARE_AB = RuleImage(roi_front=(1183,308,45,39), roi_back=(1183,308,45,39), threshold=0.8, method="Template matching", file="./tasks/WeeklyTrifles/area_boss/area_boss_wt_share_ab.png")
+	I_WT_SHARE_AB = RuleImage(roi_front=(1187,273,45,39), roi_back=(1176,90,76,326), threshold=0.8, method="Template matching", file="./tasks/WeeklyTrifles/area_boss/area_boss_wt_share_ab.png")
 	# 分享勾玉 
 	I_WT_AB_JADE = RuleImage(roi_front=(977,552,44,47), roi_back=(977,552,44,47), threshold=0.8, method="Template matching", file="./tasks/WeeklyTrifles/area_boss/area_boss_wt_ab_jade.png")
 	# 微信分享 


### PR DESCRIPTION
- 更新 roiFront 和 roiBack 的区域坐标，以适配当前游戏界面中分享按钮的实际位置

## Summary by Sourcery

Bug Fixes:
- 更新 WeeklyTrifles 分享按钮图片的 ROI 坐标，以确保在当前游戏界面中能够被正确检测。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Update ROI coordinates for the WeeklyTrifles share button image to ensure correct detection on the current game interface.

</details>