### PR TITLE
fix(BudokaiTournament): close boss detail when tickets run out

### DIFF
--- a/tasks/BudokaiTournament/assets.py
+++ b/tasks/BudokaiTournament/assets.py
@@ -10,6 +10,11 @@ from module.atom.list import RuleList
 class BudokaiTournamentAssets: 
 
 
+	# Click Rule Assets
+	# Close cultivation drills boss detail
+	C_BOSS_DETAIL_CLOSE = RuleClick(roi_front=(1182,73,47,43), roi_back=(1182,73,47,43), name="boss_detail_close")
+
+
 	# Image Rule Assets
 	# 自己发现 
 	I_IMG2 = RuleImage(roi_front=(225,70,60,54), roi_back=(187,48,152,432), threshold=0.8, method="Template matching", file="./tasks/BudokaiTournament/bt/bt_img2.png")

--- a/tasks/BudokaiTournament/bt/click.json
+++ b/tasks/BudokaiTournament/bt/click.json
@@ -1,0 +1,8 @@
+[
+  {
+    "itemName": "boss_detail_close",
+    "roiFront": "1182,73,47,43",
+    "roiBack": "1182,73,47,43",
+    "description": "Close cultivation drills boss detail"
+  }
+]

--- a/tasks/BudokaiTournament/script_task.py
+++ b/tasks/BudokaiTournament/script_task.py
@@ -340,6 +340,9 @@ class ScriptTask(Foot):
             self.lock_team(self.conf.general_battle)
             if not self.check_tickets_enough():
                 logger.warning(f'No tickets left, wait for next time')
+                if not self.ui_click(self.C_BOSS_DETAIL_CLOSE, stop=self.I_CHECK_BATTLE_BOSS,
+                                     interval=1, timeout=10):
+                    raise GameStuckError('Unable to close cultivation drills boss detail')
                 break
             if self.conf.daily_training.random_sleep:
                 random_sleep(probability=0.2)


### PR DESCRIPTION
## What changed

- add a click rule for the cultivation drills boss-detail close button
- close the detail overlay when ticket OCR reports no remaining attempts
- wait for the boss list marker and fail explicitly after 10 seconds if the overlay cannot be closed

## Why

When cultivation-drill tickets are exhausted, the task breaks out while the boss detail overlay is still open. The following navigation then repeatedly clicks the yellow back button behind the overlay until `GameTooManyClickError`.

## Impact

The task now closes the overlay before returning from the cultivation-drills loop, preventing the repeated yellow-back click failure. Other `BudokaiTournament` branches are unchanged.

## Validation

- compiled `tasks/BudokaiTournament`
- parsed the new click asset and checked the generated ROI
- replayed six real failure screenshots; the close icon matched at `(1182, 73)` with scores `0.9644-0.9771`
- live MuMu test with `ADB_NC + minitouch`: close icon score `0.9771`, click `(1203, 97) @ boss_detail_close`, and the boss-list marker reappeared
- `git diff --check`

The exact exhausted-ticket path could not be naturally replayed during the live test because the `自己发现` entry was no longer present; the close action and post-close state transition were tested live without starting a challenge or consuming a ticket.

## Summary by Sourcery

确保在门票用尽时关闭修炼试炼 Boss 详情浮层，以防止导航被卡在浮层后面。

Bug Fixes:
- 当门票 OCR 显示没有剩余次数时，关闭修炼试炼 Boss 详情浮层，避免反复点击返回按钮并触发 `GameTooManyClickError`。

Enhancements:
- 在退出循环时，为关闭修炼试炼 Boss 详情浮层添加专用点击规则和基于超时的保护措施。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure cultivation drills boss detail overlay is closed when tickets are exhausted to prevent navigation from getting stuck behind the overlay.

Bug Fixes:
- Close the cultivation drills boss detail overlay when ticket OCR reports no remaining attempts to avoid repeated back-button clicks and GameTooManyClickError.

Enhancements:
- Add a dedicated click rule and timeout-based safeguard for closing the cultivation drills boss detail overlay when exiting the loop.

</details>