### PR TITLE
docs(README): 修复 Star History 图表链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ OAS 在其基础上进行了如下优化：
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=runhey/OnmyojiAutoScript&type=Date)](https://star-history.com/#runhey/OnmyojiAutoScript&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=runhey/OnmyojiAutoScript&type=Date)](https://star-history.dera.page/#runhey/OnmyojiAutoScript&Date)
 
 
 ## ⚡ Visitor count


### PR DESCRIPTION
当前 Star History 图表因 GitHub stargazer API 限制而无法正常显示。此修改将图表切换到可正常工作的服务，恢复仓库星标历史展示。相关引用由 PR #732 (commit f5a5723) 引入。

## Summary by Sourcery

Documentation:
- 修复 README 中的 Star History 图表链接，使其指向能够正确显示仓库星标历史的服务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Fix the Star History chart link in README to point to a service that correctly displays repository star history.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 更新 README 中的 Star History 图表图片及跳转链接。
  * 将相关链接切换至新的访问地址。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->