### PR TITLE
fix(BudokaiTournament): prevent search click race

### DIFF
--- a/tasks/BudokaiTournament/script_task.py
+++ b/tasks/BudokaiTournament/script_task.py
@@ -312,6 +312,13 @@ class ScriptTask(Foot):
         while 1:
             self.screenshot()
             # --------------------------------------------------------------
+            # A delayed search click can land on the challenge button after the
+            # boss-detail page has already appeared. Recover by attaching to an
+            # already-started battle instead of waiting forever on a UI image.
+            if self.is_in_battle(False):
+                logger.warning('Cultivation drill battle already started, attach to battle process')
+                self.run_general_battle(config=self.get_general_battle_conf())
+                continue
             if (self.appear_then_click(self.I_UI_CONFIRM, interval=0.5)
                     or self.appear_then_click(self.I_UI_CONFIRM_SAMLL, interval=0.5)):
                 continue
@@ -328,10 +335,21 @@ class ScriptTask(Foot):
                 # self.put_status()
                 if cnt_scout >= self.conf.daily_training.limit_cultivation_drills:
                     raise LimitCountOut
-                if self.ui_click(self.I_IMG1, stop=self.I_IMG3, interval=1.5, timeout=10):
-                    logger.info(f'Cultivation drill done, for next time {cnt_scout}')
-                    cnt_scout += 1
-                    pass
+                # Click search only once, then wait without sending more input.
+                # Repeated clicks can cross the page transition and hit the
+                # overlapping challenge button on the boss-detail page.
+                if self.appear_then_click(self.I_IMG1, interval=1.5):
+                    transition_timer = Timer(10).start()
+                    while 1:
+                        self.screenshot()
+                        if (self.appear(self.I_IMG3) or self.appear(self.I_IMG4)
+                                or self.is_in_battle(False)):
+                            logger.info(f'Cultivation drill done, for next time {cnt_scout}')
+                            cnt_scout += 1
+                            break
+                        if transition_timer.reached():
+                            logger.warning('Wait cultivation drill boss detail timeout, retry search')
+                            break
                 continue
             if not (self.appear(self.I_IMG3) or self.appear(self.I_IMG4)):
                 continue
@@ -388,5 +406,4 @@ if __name__ == '__main__':
     t = ScriptTask(c, d)
 
     t.run()
-
 


### PR DESCRIPTION
## Summary

- click the cultivation-drill search button once and wait for the boss-detail page without sending more input
- recover by attaching to the battle handler if a delayed click has already started the battle

## Root cause

`ui_click(I_IMG1, stop=I_IMG3)` repeatedly clicked the search template while waiting for the boss-detail template. The actual minitouch event could be dispatched after the page had already changed. Because the search and challenge buttons overlap in the bottom-right area, the delayed search click could land on the challenge button and start a battle before the cultivation-drill loop was ready to handle it. The outer loop then waited for UI images until `GameStuckError`.

## Impact

The search-to-challenge transition no longer receives repeated clicks. If a battle is already running, the task attaches to the normal general-battle flow instead of getting stuck.

## Validation

- local behavior harness: 2 tests passed
  - search is clicked exactly once while waiting for the detail page
  - an already-started battle is attached without another search click
- live MuMu test with ADB_NC screenshots and minitouch input:
  - cycle 1: one `BT_IMG1` click, `BT_IMG3`, `GENERAL BATTLE START`, then `GB_WIN`
  - cycle 2: one `BT_IMG1` click, `BT_IMG3`, then `GENERAL BATTLE START`
- `git diff --check`: passed

## Summary by Sourcery

防止修炼演习搜索点击与 Boss 详情页面切换发生竞态并导致卡住，并通过附加到已经开始的战斗来恢复流程。

Bug 修复：
- 确保修炼演习搜索只被点击一次并进行等待，避免延迟点击击中重叠的挑战按钮而启动非预期战斗。
- 检测修炼演习战斗是否已经开始，并附加到通用战斗流程，而不是无限期地等待 UI 图片。

改进：
- 在修炼演习搜索点击后等待 Boss 详情页面的流程中加入超时和重试机制，以提升循环的健壮性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent cultivation drill search clicks from racing with the boss-detail transition and getting stuck, and recover by attaching to already-started battles.

Bug Fixes:
- Ensure cultivation drill search is clicked only once and waited on, avoiding delayed clicks hitting the overlapping challenge button and starting unintended battles.
- Detect when a cultivation drill battle has already started and attach to the general battle flow instead of waiting indefinitely for UI images.

Enhancements:
- Add a timeout and retry for waiting on the boss-detail page after a cultivation drill search click to improve robustness of the loop.

</details>