### PR TITLE
fix(BudokaiTournament): avoid repeated search clicks

### DIFF
--- a/tasks/BudokaiTournament/script_task.py
+++ b/tasks/BudokaiTournament/script_task.py
@@ -328,10 +328,19 @@ class ScriptTask(Foot):
                 # self.put_status()
                 if cnt_scout >= self.conf.daily_training.limit_cultivation_drills:
                     raise LimitCountOut
-                if self.ui_click(self.I_IMG1, stop=self.I_IMG3, interval=1.5, timeout=10):
-                    logger.info(f'Cultivation drill done, for next time {cnt_scout}')
-                    cnt_scout += 1
-                    pass
+                # Click search once, then wait for the boss-detail page without
+                # sending another input during the page transition.
+                if self.appear_then_click(self.I_IMG1, interval=1.5):
+                    transition_timer = Timer(10).start()
+                    while 1:
+                        self.screenshot()
+                        if self.appear(self.I_IMG3) or self.appear(self.I_IMG4):
+                            logger.info(f'Cultivation drill done, for next time {cnt_scout}')
+                            cnt_scout += 1
+                            break
+                        if transition_timer.reached():
+                            logger.warning('Wait cultivation drill boss detail timeout, retry search')
+                            break
                 continue
             if not (self.appear(self.I_IMG3) or self.appear(self.I_IMG4)):
                 continue
@@ -388,5 +397,4 @@ if __name__ == '__main__':
     t = ScriptTask(c, d)
 
     t.run()
-
 


### PR DESCRIPTION
## Summary

- click the cultivation-drill search button exactly once
- wait for either supported boss-detail image without sending more input during the page transition
- keep the change scoped to `BudokaiTournament._run_cultivation_drills`

## Root cause

The previous `ui_click` call retried `BT_IMG1` every 1.5 seconds while waiting for only `BT_IMG3`. On a slow page transition, a delayed retry could land on the challenge button after the search page had already changed, causing the battle flow to begin before the task had processed the boss-detail page.

The new flow uses `appear_then_click` once, then only refreshes screenshots until `BT_IMG3` or `BT_IMG4` appears. The existing 10-second timeout remains explicit and logs a warning before the outer loop retries.

## Scope

- changed: `tasks/BudokaiTournament/script_task.py`
- unchanged: shared click helpers, general battle, GameUi, ADB/control methods, screenshots, assets, configuration, and all other tasks

## Validation

- unit harness: 2 tests passed, including six simulated full search/detail/battle/return cycles and a static assertion that this path contains no battle-state fallback
- Python compilation passed
- `git diff --check` passed
- live MuMu/OAS test completed six real search results with exactly one `BT_IMG1` click per result, six wins, and a normal `BudokaiTournament` task exit
- the live test also covered a failed battle followed by `BT_IMG4` retry on the same search result, without issuing another search click

This supersedes the closed #1737. The false-positive battle-state fallback from that PR is not present in this change.

## Summary by Sourcery

Bug Fixes:
- 解决在首领详情页面缓慢过渡期间，重复搜索重试落在挑战按钮上而导致的战斗过早开始问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve premature battle start caused by repeated search retries landing on the challenge button during slow boss-detail page transitions.

</details>