### PR TITLE
修复契光水境式神录识别区域

### DIFF
--- a/tasks/Component/CostumeShikigami/assets.py
+++ b/tasks/Component/CostumeShikigami/assets.py
@@ -227,7 +227,7 @@ class CostumeShikigamiAssets:
 
 	# Image Rule Assets
 	# 用于判断在式神录 
-	I_CHECK_RECORDS_5 = RuleImage(roi_front=(267,76,51,46), roi_back=(265,74,55,50), threshold=0.8, method="Template matching", file="./tasks/Component/CostumeShikigami/sk5/sk5_check_records_5.png")
+	I_CHECK_RECORDS_5 = RuleImage(roi_front=(313,75,44,43), roi_back=(308,70,54,53), threshold=0.8, method="Template matching", file="./tasks/Component/CostumeShikigami/sk5/sk5_check_records_5.png")
 	# 退出式神录 
 	I_RECORD_SOUL_BACK_5 = RuleImage(roi_front=(19,9,51,44), roi_back=(19,9,51,44), threshold=0.8, method="Template matching", file="./tasks/Component/CostumeShikigami/sk5/sk5_record_soul_back_5.png")
 	# 预设 

--- a/tasks/Component/CostumeShikigami/sk5/image.json
+++ b/tasks/Component/CostumeShikigami/sk5/image.json
@@ -2,8 +2,8 @@
   {
     "itemName": "check_records_5",
     "imageName": "sk5_check_records_5.png",
-    "roiFront": "267,76,51,46",
-    "roiBack": "265,74,55,50",
+    "roiFront": "313,75,44,43",
+    "roiBack": "308,70,54,53",
     "method": "Template matching",
     "threshold": 0.8,
     "description": "用于判断在式神录"


### PR DESCRIPTION
## 修改说明

契光水境幕间皮肤下，式神录页面的 `I_CHECK_RECORDS_5` 识别区域仍指向旧位置，无法覆盖当前界面的放大镜图标。

本次修改：

- 将 `roi_front` 从 `(267,76,51,46)` 调整为 `(313,75,44,43)`
- 将 `roi_back` 从 `(265,74,55,50)` 调整为 `(308,70,54,53)`
- 同步更新运行资产定义与 `sk5/image.json` 生成源，避免重新生成资产后恢复旧坐标

## 验证

使用 1280×720 的契光水境式神录截图进行模板匹配，放大镜模板定位在 `(313,75)`，匹配度为 `0.973195`，高于当前阈值 `0.8`。

## Summary by Sourcery

更新契光水境式神录检查区域配置以恢复放大镜图标识别。

Bug Fixes:
- 修正契光水境式神录中式神录检查图像的识别区域，使其能够覆盖当前界面的放大镜图标。

Chores:
- 同步更新运行资产定义和生成源中的识别区域配置，避免重新生成资产后坐标回退。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更新契光水境式神录检查区域配置以恢复放大镜图标识别。

Bug Fixes:
- 修正契光水境式神录中式神录检查图像的识别区域，使其能够覆盖当前界面的放大镜图标。

Chores:
- 同步更新运行资产定义和生成源中的识别区域配置，避免重新生成资产后坐标回退。

</details>