### PR TITLE
Replace deprecated BaseModel.dict() with model_dump()

### DIFF
--- a/module/config/config.py
+++ b/module/config/config.py
@@ -172,7 +172,7 @@ class Config(ConfigState, ConfigManual, ConfigWatcher, ConfigMenu):
         保存配置文件
         :return:
         """
-        self.model.write_json(self.config_name, self.model.dict())
+        self.model.write_json(self.config_name, self.model.model_dump())
 
     def update_scheduler(self) -> None:
         """
@@ -183,7 +183,7 @@ class Config(ConfigState, ConfigManual, ConfigWatcher, ConfigMenu):
         waiting_task = []
         error = []
         self.scheduler_update_dt = datetime.now()
-        for key, value in self.model.dict().items():
+        for key, value in self.model.model_dump().items():
             func = Function(key, value)
             if not func.enable:
                 continue

--- a/module/config/config_model.py
+++ b/module/config/config_model.py
@@ -209,7 +209,7 @@ class ConfigModel(ConfigBase):
             logger.warning(f'{task} is no inexistence')
             return ''
 
-        schema2 = task_gui.schema()
+        schema2 = task_gui.model_json_schema()
         # https://github.com/pydantic/pydantic/discussions/5687
         if 'definitions' in schema2:
             if 'Scheduler' in schema2['definitions']:
@@ -232,7 +232,7 @@ class ConfigModel(ConfigBase):
         if task is None:
             logger.warning(f'{task_name} is no inexistence')
             return ''
-        return task.json()
+        return task.model_dump_json()
 
     def save(self) -> None:
         """
@@ -463,7 +463,7 @@ class ConfigModel(ConfigBase):
     def reset_datetime_for_all_enabled_tasks(self, task_datetime: datetime):
         logger.warn(f"trying to reset datetime of all tasks to: {task_datetime}")
         # logger.info(f"current config: {self.dict()}")
-        data = self.dict()
+        data = self.model_dump()
         self.replace_next_run(data, task_datetime)
         # logger.info(f"new config: {data}")
 

--- a/module/config/config_modify.py
+++ b/module/config/config_modify.py
@@ -76,7 +76,7 @@ class ConfigModify(Config):
         :return:
         """
         result = {}
-        for key, value in self.model.dict().items():
+        for key, value in self.model.model_dump().items():
             if isinstance(value, str):
                 continue
             if key == "restart":

--- a/module/server/tool_router.py
+++ b/module/server/tool_router.py
@@ -143,7 +143,7 @@ async def annotator_upload_images(data: UploadImagesBody):
     try:
         images = annotator_manager.save_uploaded_images_base64(
             data.session_id,
-            [item.dict() for item in data.images],
+            [item.model_dump() for item in data.images],
         )
         return {"code": "ok", "images": images}
     except AnnotatorError as e:

--- a/script.py
+++ b/script.py
@@ -264,7 +264,7 @@ class Script:
         :return:
         """
         result = {}
-        for key, value in self.config.model.dict().items():
+        for key, value in self.config.model.model_dump().items():
             if isinstance(value, str):
                 continue
             if key == "restart":


### PR DESCRIPTION
Fix #1753

Replace the deprecated `BaseModel.dict()` call in `script.py` with
`model_dump()` (available since pydantic 2.0.0, identical semantics), removing
the `PydanticDeprecatedSince20` warning emitted on pydantic 2.x.

## Sourcery 摘要

将已弃用的配置序列化方法替换为 Pydantic 支持的模型转储 API。

错误修复：
- 移除序列化配置模型时 Pydantic 2.x 的弃用警告。

增强功能：
- 更新配置序列化，以使用受支持的 Pydantic 模型转储 API，同时保留现有行为。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

将整个应用中的模型序列化迁移到受支持的 Pydantic 2 API。

错误修复：
- 通过将已弃用的模型序列化 API 替换为受支持的等效 API，移除 Pydantic 2.x 弃用警告。

增强功能：
- 更新配置、任务、架构和上传序列化，以使用 Pydantic 2 API，同时保留现有行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate model serialization throughout the application to supported Pydantic 2 APIs.

Bug Fixes:
- Remove Pydantic 2.x deprecation warnings by replacing deprecated model serialization APIs with their supported equivalents.

Enhancements:
- Update configuration, task, schema, and upload serialization to use Pydantic 2 APIs while preserving existing behavior.

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 更新配置数据的序列化方式，提升任务列表、配置保存及调度信息返回的稳定性。
  * 迁移至新版数据模型接口，减少已弃用方法带来的兼容性问题。
  * 优化图片上传过程中的数据处理，保持原有上传与错误处理行为不变。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->