### PR TITLE
refactor: 将 anti_ban 作息逻辑从 script.py 抽出为 AntiBanGuard

### DIFF
--- a/module/config/anti_ban.py
+++ b/module/config/anti_ban.py
@@ -1,0 +1,54 @@
+# This Python file uses the following encoding: utf-8
+"""防风控作息看守器: 睡眠窗 / 每日活跃上限 / 强制长休息, 由 Script 持有。"""
+from datetime import datetime, timedelta
+
+
+class AntiBanGuard:
+    def __init__(self) -> None:
+        self.reset()
+
+    def reset(self) -> None:
+        self._active_date = None
+        self._active_seconds_today = 0.0
+        self._rest_until = None
+
+    @staticmethod
+    def _in_sleep_window(t, start, end) -> bool:
+        if start == end:
+            return False
+        if start < end:
+            return start <= t < end
+        return t >= start or t < end
+
+    @staticmethod
+    def _next_time_point(now: datetime, end) -> datetime:
+        candidate = now.replace(hour=end.hour, minute=end.minute, second=end.second, microsecond=0)
+        if candidate <= now:
+            candidate += timedelta(days=1)
+        return candidate
+
+    def _roll_day(self, today) -> None:
+        if self._active_date != today:
+            self._active_date = today
+            self._active_seconds_today = 0.0
+
+    def record_active(self, seconds: float) -> None:
+        self._roll_day(datetime.now().date())
+        self._active_seconds_today += seconds
+
+    def wake_time(self, now: datetime, config):
+        if not config.enable:
+            return None
+        wake = None
+        if self._in_sleep_window(now.time(), config.sleep_start, config.sleep_end):
+            wake = self._next_time_point(now, config.sleep_end)
+        limit = config.daily_active_limit.total_seconds()
+        if limit > 0:
+            self._roll_day(now.date())
+            if self._rest_until and now < self._rest_until:
+                wake = max(wake, self._rest_until) if wake else self._rest_until
+            elif self._active_seconds_today >= limit:
+                self._rest_until = now + config.long_rest_duration
+                self._active_seconds_today = 0.0
+                wake = max(wake, self._rest_until) if wake else self._rest_until
+        return wake

--- a/script.py
+++ b/script.py
@@ -30,6 +30,7 @@ from module.config.utils import convert_to_underscore
 from module.config.config import Config
 from module.config.config_model import ConfigModel
 from module.config.instance_guard import InstanceGuard
+from module.config.anti_ban import AntiBanGuard
 from module.device.device import Device
 from module.device.env import IS_WINDOWS
 from module.base.utils import load_module
@@ -61,6 +62,7 @@ class Script:
         self.loop_thread: Thread = None
         # 跨进程排队管理器（仅在 queue_mode=True 时初始化）
         self.instance_guard: InstanceGuard = None
+        self.anti_ban_guard: AntiBanGuard = AntiBanGuard()
 
     @cached_property
     def config(self) -> "Config":
@@ -318,42 +320,6 @@ class Script:
             if self.config.should_reload():
                 return False
 
-    @staticmethod
-    def _in_sleep_window(t, start, end) -> bool:
-        if start == end:
-            return False
-        if start < end:
-            return start <= t < end
-        return t >= start or t < end
-
-    @staticmethod
-    def _next_time_point(now: datetime, end) -> datetime:
-        candidate = now.replace(hour=end.hour, minute=end.minute, second=end.second, microsecond=0)
-        if candidate <= now:
-            candidate += timedelta(days=1)
-        return candidate
-
-    def _antiban_wake_time(self, now: datetime):
-        ab = self.config.script.anti_ban
-        if not ab.enable:
-            return None
-        wake = None
-        if self._in_sleep_window(now.time(), ab.sleep_start, ab.sleep_end):
-            wake = self._next_time_point(now, ab.sleep_end)
-        limit = ab.daily_active_limit.total_seconds()
-        if limit > 0:
-            if getattr(self, '_active_date', None) != now.date():
-                self._active_date = now.date()
-                self._active_seconds_today = 0
-            rest_until = getattr(self, '_rest_until', None)
-            if rest_until and now < rest_until:
-                wake = max(wake, rest_until) if wake else rest_until
-            elif getattr(self, '_active_seconds_today', 0) >= limit:
-                self._rest_until = now + ab.long_rest_duration
-                self._active_seconds_today = 0
-                wake = max(wake, self._rest_until) if wake else self._rest_until
-        return wake
-
     def get_next_task(self) -> str:
         """
         获取下一个任务的名字, 大驼峰。
@@ -365,7 +331,7 @@ class Script:
             if self.state_queue:
                 self.state_queue.put({"schedule": self.config.get_schedule_data()})
             now = datetime.now()
-            antiban_wake = self._antiban_wake_time(now)
+            antiban_wake = self.anti_ban_guard.wake_time(now, self.config.script.anti_ban)
             if antiban_wake is not None:
                 task.next_run = max(task.next_run, antiban_wake)
             if not self._try_acquire_queue_token():
@@ -664,9 +630,7 @@ class Script:
         start_day = date.today()
         logger.info(f'Start scheduler loop: {self.config_name}')
         self.config.model.running_task = ''
-        self._active_seconds_today = 0
-        self._active_date = date.today()
-        self._rest_until = None
+        self.anti_ban_guard.reset()
 
         # Update GUI 防呆, 读取设置并立刻显示后台模拟器到前台
         if not self.config.script.device.run_background_only and IS_WINDOWS:
@@ -727,10 +691,7 @@ class Script:
             self.config.model.running_task = ''
             logger.info(f'Scheduler: End task `{task}`')
             self.is_first_task = False
-            if self._active_date != date.today():
-                self._active_date = date.today()
-                self._active_seconds_today = 0
-            self._active_seconds_today += (datetime.now() - _task_start).total_seconds()
+            self.anti_ban_guard.record_active((datetime.now() - _task_start).total_seconds())
 
             # Check failures
             # failed = deep_get(self.failure_record, keys=task, default=0)


### PR DESCRIPTION
回应上个 PR 合并时「script.py 已经变成一坨了」的反馈。

## 问题
防风控 PR(#1755)把 anti_ban 作息调度逻辑散插进了 script.py 的 4 处,运行时状态用 `getattr(self, '_active_*', default)` 隐式挂在 Script 类上,让本就庞大的 Script 更臃肿。

## 改动(纯结构调整,行为不变)
- 新增 `module/config/anti_ban.py` 的 `AntiBanGuard`:自持状态(`_active_date`/`_active_seconds_today`/`_rest_until`),把睡眠窗/每日活跃上限/强制休息逻辑收拢为 `reset()` / `record_active()` / `wake_time()`,镜像现有 `InstanceGuard` 范式。
- `script.py` 抽空散插逻辑,只留 1 个 import + 1 个构造 + 3 处一行调用;删掉挂在 Script 上的隐式 anti_ban 状态。净减约 35 行。

## 验证
- `py_compile` + 导入无环通过。
- 逐条行为等价核对:关闭返回 None、睡眠窗(含跨午夜)唤醒点、每日上限触发强制休息、跨午夜累计重置,全部与原实现一致。

## Sourcery 总结

增强功能：
- 将防封禁调度和活动跟踪逻辑从 Script 中提取到专用的 AntiBanGuard 中，在保持现有行为不变的同时降低 Script 的复杂性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Extract anti-ban scheduling and activity tracking from Script into a dedicated AntiBanGuard, reducing Script complexity while preserving existing behavior.

</details>