### PR TITLE
fix(RyouToppa): 任务结束后返回庭院避免探索任务不开启加成

### DIFF
--- a/tasks/RyouToppa/script_task.py
+++ b/tasks/RyouToppa/script_task.py
@@ -186,9 +186,9 @@ class ScriptTask(GeneralBattle, GameUi, SwitchSoul, RyouToppaAssets):
                 continue
 
 
-        # 回 page_main 失败
-        # self.ui_current = page_ryou_toppa
-        # self.ui_goto(page_main)
+        # 回 page_main
+        self.ui_get_current_page()
+        self.ui_goto(page_main)
         if success:
             self.set_next_run(task='RyouToppa', finish=True, server=True, success=True)
         else:


### PR DESCRIPTION
## Sourcery 摘要

错误修复：
- 确保 RyouToppa 在任务结束后返回主庭院，以便后续探索任务能够获得其奖励。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure RyouToppa returns to the main courtyard after the task ends so subsequent exploration tasks can receive their bonuses.

</details>