### PR TITLE
feat(DemonEncounter): 逢魔之时增加今日挑战次数检测；fix(RichMan): 寮商店购买后先重新识别再滑动

### DIFF
--- a/tasks/DemonEncounter/assets.py
+++ b/tasks/DemonEncounter/assets.py
@@ -125,6 +125,8 @@ class DemonEncounterAssets:
 	# Ocr Rule Assets
 	# 计数已经开启多少的 
 	O_DE_COUNTER = RuleOcr(roi=(1204,685,48,34), area=(1204,685,48,34), mode="DigitCounter", method="Default", keyword="", name="de_counter")
+	# 现世逢魔顶部今日挑战次数X/1的最小识别区, 0/1表示已打过直接结束 
+	O_DE_CHALLENGE_COUNT = RuleOcr(roi=(680,68,75,36), area=(680,68,75,36), mode="Full", method="Default", keyword="", name="de_challenge_count")
 
 
 	# Click Rule Assets

--- a/tasks/DemonEncounter/demon/ocr.json
+++ b/tasks/DemonEncounter/demon/ocr.json
@@ -7,5 +7,14 @@
     "method": "Default",
     "keyword": "",
     "description": "计数已经开启多少的"
+  },
+  {
+    "itemName": "de_challenge_count",
+    "roiFront": "680,68,75,36",
+    "roiBack": "680,68,75,36",
+    "mode": "Full",
+    "method": "Default",
+    "keyword": "",
+    "description": "现世逢魔顶部今日挑战次数X/1的最小识别区, 0/1表示已打过直接结束"
   }
 ]

--- a/tasks/DemonEncounter/script_task.py
+++ b/tasks/DemonEncounter/script_task.py
@@ -3,6 +3,7 @@
 # github https://github.com/runhey
 import time
 from time import sleep
+import re
 
 from enum import Enum
 from cached_property import cached_property
@@ -48,11 +49,29 @@ class ScriptTask(GameUi, GeneralBattle, DemonEncounterAssets, SwitchSoul):
             self.ui_goto(page_shikigami_records)
             self.checkout_soul()
         self.ui_goto(page_demon_encounter_realworld)
+        # 顶部"今日挑战次数:X/1"检测, 0/1表示今日已打过, 直接结束
+        if self.check_challenge_done():
+            logger.info('Challenge count 0/1, already challenged today')
+            self.set_next_run(task='DemonEncounter', success=True, finish=False)
+            raise TaskEnd('DemonEncounter')
         self.execute_lantern()
         self.execute_boss()
 
         self.set_next_run(task='DemonEncounter', success=True, finish=False)
         raise TaskEnd('DemonEncounter')
+
+    def check_challenge_done(self) -> bool:
+        """
+        OCR识别现世逢魔顶部"今日挑战次数:X/1"
+        :return: True表示0/1今日已打过
+        """
+        results = self.O_DE_CHALLENGE_COUNT.detect_and_ocr(self.device.image)
+        text = ''.join(r.ocr_text for r in results)
+        m = re.search(r'([01])\s*/\s*1', text)
+        if not m:
+            logger.warning(f'Challenge count not recognized: [{text}], continue by default')
+            return False
+        return m.group(1) == '0'
 
     def checkout_soul(self):
         """

--- a/tasks/RichMan/guild.py
+++ b/tasks/RichMan/guild.py
@@ -67,8 +67,10 @@ class Guild(Buy, GameUi, RichManAssets):
             *([(self.I_GUILD_SKIN, self._guild_skin_ticket)] if con.skin_ticket else []),
         ]
         items_all_done = False
+        swipe_no_progress = 0
         while 1:
             self.screenshot()
+            bought_this_round = False
             for item in items:
                 button, func = item
                 if not self.appear(button):
@@ -80,11 +82,22 @@ class Guild(Buy, GameUi, RichManAssets):
                     if item == items[-1]:
                         items_all_done = True
                     items.remove(item)
+                    bought_this_round = True
+                    swipe_no_progress = 0
                 except ButtonException as e:
                     logger.warning(f'Button {button.name} click failed')
                 break
             if items_all_done:
                 logger.info(f'All items have been purchased {items}')
+                break
+            # 刚购买成功: 先等待界面稳定并重新识别, 视野内还有商品就继续买, 不要急着滑动
+            if bought_this_round:
+                time.sleep(1)
+                continue
+            # 连续多次滑动都没有买到东西, 防止无限滑动触发点击保护
+            swipe_no_progress += 1
+            if swipe_no_progress >= 8:
+                logger.warning(f'Swipe {swipe_no_progress} times without buying, stop guild store')
                 break
             if self.swipe(self.S_GUILD_STORE, interval=1.5):
                 time.sleep(2)


### PR DESCRIPTION
提升大富翁购买寮商店的稳定性和逢魔的稳定性。寮商店每次只购买蓝票，碎片和皮肤券都被跳过了，逢魔偶尔卡死

## Sourcery 总结

改进恶魔遭遇完成处理，并提升公会商店购买的稳定性。

错误修复：
- 当今日的挑战配额已用完时，防止恶魔遭遇再次运行。
- 提升公会商店购买的可靠性，以便在滚动前重新检测新购买的物品，并在多次滚动没有进展后停止。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过处理每日尝试次数耗尽的情况、稳定购买流程，并增强图像匹配对尺寸过小截图的适应性，提高 DemonEncounter 和公会商店的可靠性。

错误修复：
- 当今天的挑战次数已用完后，阻止 DemonEncounter 再次运行。
- 改进公会商店购买流程，使其在每次购买后重新检测物品，并在多次无效滑动后停止。
- 当截图或裁剪区域小于目标模板时，防止模板匹配失败。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

改进 DemonEncounter 完成处理，并增强公会商店购买和图像识别的稳定性。

Bug 修复：
- 每日挑战次数用尽后，防止 DemonEncounter 再次运行。
- 改进公会商店购买流程，在滚动前重新检查每次成功的购买，并在重复滚动但没有产生结果时最终停止。
- 当屏幕截图或裁剪区域小于目标图像时，防止模板匹配崩溃。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve DemonEncounter completion handling and stabilize guild store purchasing and image recognition.

Bug Fixes:
- Prevent DemonEncounter from running again after the daily challenge quota has been exhausted.
- Improve guild store purchasing so each successful purchase is rechecked before scrolling and repeated unproductive scrolling eventually stops.
- Prevent template matching from crashing when screenshots or cropped regions are smaller than the target image.

</details>

</details>

</details>