### PR TITLE
兼容mumu的安卓15

### DIFF
--- a/module/device/method/adb.py
+++ b/module/device/method/adb.py
@@ -160,7 +160,15 @@ class Adb(Connection):
     @retry
     @Config.when(DEVICE_OVER_HTTP=False)
     def screenshot_adb(self):
-        data = self.adb_shell(['screencap', '-p'], stream=True)
+
+        data = b'ss'
+        # 判断系统是安卓12还是安卓15,安卓15截图增加-d 参数
+        sysversion = self.adb_shell(['getprop', 'ro.build.version.release'], stream=False)
+        if sysversion == "15" :
+            data = self.adb_shell(['screencap','-d', '4619827767814508545', '-p'], stream=True)
+        else:
+            data = self.adb_shell(['screencap', '-p'], stream=True)
+
         if len(data) < 500:
             logger.warning(f'Unexpected screenshot: {data}')
 
@@ -170,6 +178,8 @@ class Adb(Connection):
     @Config.when(DEVICE_OVER_HTTP=True)
     def screenshot_adb(self):
         data = self.adb_shell(['screencap'], stream=True)
+
+
         if len(data) < 500:
             logger.warning(f'Unexpected screenshot: {data}')
 
@@ -186,7 +196,12 @@ class Adb(Connection):
     @retry
     def click_adb(self, x, y):
         start = time.time()
-        self.adb_shell(['input', 'tap', x, y])
+        # 安卓15需要制定屏幕ID，增加制定屏幕的判断
+        sysversion = self.adb_shell(['getprop', 'ro.build.version.release'], stream=False)
+        if sysversion == "15":
+            self.adb_shell(['input','-d','2', 'tap', x, y])
+        else:
+            self.adb_shell(['input', 'tap', x, y])
         if time.time() - start <= 0.05:
             self.sleep(0.05)
 

--- a/module/device/method/adb.py
+++ b/module/device/method/adb.py
@@ -177,7 +177,11 @@ class Adb(Connection):
     @retry
     @Config.when(DEVICE_OVER_HTTP=True)
     def screenshot_adb(self):
-        data = self.adb_shell(['screencap'], stream=True)
+        sysversion = self.adb_shell(['getprop', 'ro.build.version.release'], stream=False)
+        if sysversion == "15" :
+            data = self.adb_shell(['screencap','-d', '4619827767814508545', '-p'], stream=True)
+        else:
+            data = self.adb_shell(['screencap'], stream=True)
 
 
         if len(data) < 500:


### PR DESCRIPTION
1 截图的时候，需要指定displayid，而且id不能指定为1,2,3，需要指定一个长字符串
2 点击的时候也需要指定id，通过类似1,2,的方式指定

## Sourcery 摘要

错误修复：
- 通过定位所需的显示屏 ID，为 ADB 截图和点击操作添加 Android 15 兼容性。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

支持 Android 15 特定显示屏的 ADB 截图和输入操作。

错误修复：
- 通过指定所需的显示屏 ID，增加 ADB 截图对 Android 15 的兼容性。
- 通过指定适当的显示屏，增加 ADB 点击输入对 Android 15 的兼容性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support Android 15 display-specific ADB screenshot and input operations.

Bug Fixes:
- Add Android 15 compatibility for ADB screenshots by targeting the required display ID.
- Add Android 15 compatibility for ADB tap input by targeting the appropriate display.

</details>

</details>