### PR TITLE
fix(emulator): support MuMu Android 15 instance startup

### DIFF
--- a/module/device/platform2/emulator_base.py
+++ b/module/device/platform2/emulator_base.py
@@ -100,12 +100,13 @@ class EmulatorInstanceBase:
         Convert MuMu 12 instance name to instance id.
         Example names:
             MuMuPlayer-12.0-3
+            MuMuPlayerGlobal-15.0-1
             YXArkNights-12.0-1
 
         Returns:
             int: Instance ID, or None if this is not a MuMu 12 instance
         """
-        res = re.search(r'MuMuPlayer(?:Global)?-12.0-(\d+)', self.name)
+        res = re.search(r'MuMuPlayer(?:Global)?-(?:12|15)\.0-(\d+)', self.name)
         if res:
             return int(res.group(1))
         res = re.search(r'YXArkNights-12.0-(\d+)', self.name)

--- a/module/device/platform2/platform_windows.py
+++ b/module/device/platform2/platform_windows.py
@@ -180,7 +180,10 @@ class PlatformWindows(PlatformBase, EmulatorManager):
             # MuMuPlayer.exe -v 0
             if instance.MuMuPlayer12_id is None:
                 logger.warning(f'Cannot get MuMu instance index from name {instance.name}')
-            self.execute(f'"{exe}" -v {instance.MuMuPlayer12_id}', show_window=show_window)
+            if re.search(r'MuMuPlayer(?:Global)?-15\.0-\d+', instance.name):
+                self.execute(f'"{Emulator.single_to_console(exe)}" control -v {instance.MuMuPlayer12_id} --version 15 launch', show_window=show_window)
+            else:
+                self.execute(f'"{exe}" -v {instance.MuMuPlayer12_id}', show_window=show_window)
         elif instance == Emulator.LDPlayerFamily:
             # ldconsole.exe launch --index 0
             self.execute(f'"{Emulator.single_to_console(exe)}" launch --index {instance.LDPlayer_id}', show_window=show_window)
@@ -236,7 +239,11 @@ class PlatformWindows(PlatformBase, EmulatorManager):
             # MuMuManager.exe api -v 1 shutdown_player
             if instance.MuMuPlayer12_id is None:
                 logger.warning(f'Cannot get MuMu instance index from name {instance.name}')
-            self.execute(f'"{Emulator.single_to_console(exe)}" api -v {instance.MuMuPlayer12_id} shutdown_player')
+            if re.search(r'MuMuPlayer(?:Global)?-15\.0-\d+', instance.name):
+                # Finish shutdown before emulator_start() launches the same instance.
+                self.execute(f'"{Emulator.single_to_console(exe)}" control -v {instance.MuMuPlayer12_id} --version 15 shutdown').wait(timeout=30)
+            else:
+                self.execute(f'"{Emulator.single_to_console(exe)}" api -v {instance.MuMuPlayer12_id} shutdown_player')
         elif instance == Emulator.LDPlayerFamily:
             # ldconsole.exe quit --index 0
             self.execute(f'"{Emulator.single_to_console(exe)}" quit --index {instance.LDPlayer_id}')


### PR DESCRIPTION
MuMu Android 15 instances cannot be launched automatically: their names do not match the 12.0-only ID parser, and the current MuMu manager uses `control` rather than the legacy launcher/API commands. OAS consequently opens the manager without starting the requested instance.

Recognize 15.0 instance names and use `MuMuManager.exe control -v <id> --version 15 launch/shutdown` for those instances. Wait for the shutdown command to finish before launching to avoid overlapping requests. Existing Android 12 and YXArkNights behavior is preserved.

Validation:
- Offline regression: 9 parser cases (including index zero, global/local names, legacy names and malformed input).
- Offline capture of the actual start/stop methods: 24 command cases across Android 12/15, global/local names and multiple indices; no emulator actions in these tests.
- Both modified modules compile; `git diff --check` passes.

Live verification: MuMu Global 6.5.6.0 / Android 15 on Windows. Starting the existing OAS scheduler from a stopped instance completed emulator startup and established ADB connectivity. The scheduler was left running. Android 12 command compatibility was checked offline only. No account configuration, device logs or recordings are included.

## Sourcery 摘要

为 MuMu Android 15 实例实现可靠的自动生命周期管理。

新功能：
- 支持自动启动和关闭 MuMu Android 15 实例。

错误修复：
- 修复 MuMu Android 15 实例的模拟器调度问题，使请求的实例能够正确启动并通过 ADB 连接。

增强功能：
- 保留现有的 MuMu Android 12 和 YXArkNights 命令行为，同时防止 Android 15 的关闭和启动请求重叠。

测试：
- 增加离线回归测试，覆盖 MuMu 实例名称解析以及特定平台的启动/停止命令生成。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable reliable automatic lifecycle management for MuMu Android 15 instances.

New Features:
- Support automatic startup and shutdown of MuMu Android 15 instances.

Bug Fixes:
- Fix emulator scheduling for MuMu Android 15 instances so requested instances launch and connect through ADB correctly.

Enhancements:
- Preserve existing MuMu Android 12 and YXArkNights command behavior while preventing overlapping Android 15 shutdown and launch requests.

Tests:
- Add offline regression coverage for MuMu instance name parsing and platform-specific start/stop command generation.

</details>