### PR TITLE
fix: RuleAnimate uses full screenshot as template causing false animation-stable and invalid template

### DIFF
--- a/module/atom/animate.py
+++ b/module/atom/animate.py
@@ -55,7 +55,7 @@ class RuleAnimate(RuleImage):
         @return:
         """
         if self._last_image is None:
-            self._last_image = image
+            self._last_image = self.corp(image, self.roi_front)
             return False
 
         self._image = self._last_image

--- a/module/atom/image.py
+++ b/module/atom/image.py
@@ -156,9 +156,9 @@ class RuleImage(RuleImageMallResourceMixin):
 
         if mat is None or mat.shape[0] == 0 or mat.shape[1] == 0:
             logger.error(f"Template image is invalid: {mat.shape}")
-            return False  # 模板无效，匹配失败
+            return False  # 模板无效, 匹配失败
         if mat.shape[0] > source.shape[0] or mat.shape[1] > source.shape[1]:
-            # 模板大于源图，视为无效匹配（避免 matchTemplate 的异常行为）
+            # 模板大于源图, 视为无效匹配(避免 matchTemplate 的异常行为)
             return False
 
         res = cv2.matchTemplate(source, mat, cv2.TM_CCOEFF_NORMED)
@@ -203,9 +203,6 @@ class RuleImage(RuleImageMallResourceMixin):
         if mat is None or mat.shape[0] == 0 or mat.shape[1] == 0:
             logger.error(f"Template image is invalid: {mat.shape}")
             return False
-        if mat.shape[0] > source.shape[0] or mat.shape[1] > source.shape[1]:
-            # 模板大于源图，视为无效匹配（避免 matchTemplate 的异常行为）
-            return False
 
         # 预计算模板尺寸
         mat_h, mat_w = mat.shape[:2]
@@ -221,6 +218,9 @@ class RuleImage(RuleImageMallResourceMixin):
 
             # 跳过无效缩放
             if scaled_w < 10 or scaled_h < 10:
+                continue
+            # 缩放后仍大于源图则跳过该尺度(避免 matchTemplate 契约问题)
+            if scaled_w > source_w or scaled_h > source_h:
                 continue
 
             try:

--- a/module/atom/image.py
+++ b/module/atom/image.py
@@ -157,6 +157,9 @@ class RuleImage(RuleImageMallResourceMixin):
         if mat is None or mat.shape[0] == 0 or mat.shape[1] == 0:
             logger.error(f"Template image is invalid: {mat.shape}")
             return False  # 模板无效，匹配失败
+        if mat.shape[0] > source.shape[0] or mat.shape[1] > source.shape[1]:
+            # 模板大于源图，视为无效匹配（避免 matchTemplate 的异常行为）
+            return False
 
         res = cv2.matchTemplate(source, mat, cv2.TM_CCOEFF_NORMED)
         min_val, max_val, min_loc, max_loc = cv2.minMaxLoc(res)  # 最小匹配度，最大匹配度，最小匹配度的坐标，最大匹配度的坐标
@@ -199,6 +202,9 @@ class RuleImage(RuleImageMallResourceMixin):
 
         if mat is None or mat.shape[0] == 0 or mat.shape[1] == 0:
             logger.error(f"Template image is invalid: {mat.shape}")
+            return False
+        if mat.shape[0] > source.shape[0] or mat.shape[1] > source.shape[1]:
+            # 模板大于源图，视为无效匹配（避免 matchTemplate 的异常行为）
             return False
 
         # 预计算模板尺寸


### PR DESCRIPTION
### 问题
探索任务中 RuleAnimate.stable() 第一次调用把整张截图(1280x720)存为模板，第二次调用时 cv2.matchTemplate 模板大于源图(66x265 ROI)，在部分 OpenCV 版本下不抛异常而是交换匹配，导致：
1. 进入探索后滑动 1~2 次就被误判为 Animation Stable，反复进出探索，找不到高亮小怪
2. 匹配成功时 roi_front 被污染到屏幕外(x=2426)，corp 越界切片产生 (265, 0, 3) 空模板，此后永久报 "Template image is invalid"，最终 GameTooManyClickError 触发游戏重启

### 修复
1. animate.py: stable() 第一次调用改为裁剪 ROI（self.corp(image, self.roi_front)），不再用整张截图作模板
2. image.py: match()/match_multi_scale() 增加模板尺寸校验，模板大于源图时直接判定不匹配

### 验证
- 用真实截图模拟复现了 (265,0,3) 的产生路径，修复后 ROI 不再越界，模板恒为 (265,66,3)，stable 序列恢复正常
- py_compile 语法通过

## Sourcery 总结

确保动画检测使用有效的区域模板，并安全处理大于源图像的模板。

错误修复：
- 防止动画稳定性检查使用全屏截图作为模板，避免误判为稳定状态以及区域越界导致的数据损坏。
- 当模板大于源图像时，拒绝模板匹配，以防止 OpenCV 出现无效的匹配行为。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

确保动画检测使用有效的区域模板，并安全处理大于源图像的模板。

错误修复：
- 防止动画稳定性检测将全屏截图作为其模板，从而避免误判为稳定状态以及无效的区域更新。
- 当模板尺寸超过源图像尺寸时，拒绝执行模板匹配，以避免 OpenCV 出现无效的匹配行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure animation detection uses a valid region template and safely handles templates larger than the source image.

Bug Fixes:
- Prevent animation stability detection from treating a full-screen screenshot as its template, avoiding false stable states and invalid region updates.
- Reject template matching when the template exceeds the source image dimensions, preventing invalid OpenCV matching behavior.

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复**
  - 优化多尺度模板匹配：当某个缩放比例下模板尺寸超过源图时，将跳过该比例并继续尝试其他比例。
  - 动画规则仅保存首张图像中配置的前景区域，减少不必要的数据存储。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->