### PR TITLE
御魂清理任务修复识别条件

### DIFF
--- a/tasks/SoulsTidy/script_task.py
+++ b/tasks/SoulsTidy/script_task.py
@@ -142,7 +142,7 @@ class ScriptTask(GameUi, SoulsTidyAssets):
                     if firvel is None or firvel == '':
                         logger.info('ocr result is Null')
                         continue
-                    if firvel != '古':
+                    if (firvel != '古') and (firvel != '+0'):
                         # 问就是 把 +0 识别成了 古
                         logger.info('No zero level, bongna done')
                         break


### PR DESCRIPTION
之前如果 OCR 识别正确的话反而没法运行hhh

## Summary by Sourcery

Bug Fixes:
- 修复御魂清理任务对 OCR 正确识别的 +0 等级判断，避免任务被错误终止。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 修复御魂清理任务对 OCR 正确识别的 +0 等级判断，避免任务被错误终止。

</details>