### PR TITLE
fix(RichMan): handle sold-out medal shop items gracefully

### DIFF
--- a/tasks/RichMan/assets.py
+++ b/tasks/RichMan/assets.py
@@ -140,6 +140,8 @@ class RichManAssets:
 	I_ME_RED = RuleImage(roi_front=(847,146,137,129), roi_back=(141,129,864,454), threshold=0.8, method="Template matching", file="./tasks/RichMan/mall/medal/medal_me_red.png")
 	# 破碎的咒符 
 	I_ME_BROKEN = RuleImage(roi_front=(398,144,143,116), roi_back=(146,116,866,475), threshold=0.8, method="Template matching", file="./tasks/RichMan/mall/medal/medal_me_broken.png")
+	# 售罄 OCR：统计勋章商店页面中"售"字（售罄标签）数量，用于核对识别失败的商品是否均为售罄
+	O_SOLD_OUT = RuleOcr(roi=(0,100,1280,500), area=(0,100,1280,500), mode="Full", method="Default", keyword="售", name="medal_sold_out")
 	# 购买检查 
 	I_ME_CHECK_BLACK = RuleImage(roi_front=(593,229,100,100), roi_back=(558,177,202,200), threshold=0.8, method="Template matching", file="./tasks/RichMan/mall/medal/medal_me_check_black.png")
 	# 购买检查 

--- a/tasks/RichMan/assets.py
+++ b/tasks/RichMan/assets.py
@@ -140,8 +140,6 @@ class RichManAssets:
 	I_ME_RED = RuleImage(roi_front=(847,146,137,129), roi_back=(141,129,864,454), threshold=0.8, method="Template matching", file="./tasks/RichMan/mall/medal/medal_me_red.png")
 	# 破碎的咒符 
 	I_ME_BROKEN = RuleImage(roi_front=(398,144,143,116), roi_back=(146,116,866,475), threshold=0.8, method="Template matching", file="./tasks/RichMan/mall/medal/medal_me_broken.png")
-	# 售罄 OCR：统计勋章商店页面中"售"字（售罄标签）数量，用于核对识别失败的商品是否均为售罄
-	O_SOLD_OUT = RuleOcr(roi=(0,100,1280,500), area=(0,100,1280,500), mode="Full", method="Default", keyword="售", name="medal_sold_out")
 	# 购买检查 
 	I_ME_CHECK_BLACK = RuleImage(roi_front=(593,229,100,100), roi_back=(558,177,202,200), threshold=0.8, method="Template matching", file="./tasks/RichMan/mall/medal/medal_me_check_black.png")
 	# 购买检查 
@@ -150,6 +148,11 @@ class RichManAssets:
 	I_ME_CHECK_AP = RuleImage(roi_front=(590,231,100,100), roi_back=(539,194,189,162), threshold=0.8, method="Template matching", file="./tasks/RichMan/mall/medal/medal_me_check_ap.png")
 	# 购买检查 
 	I_ME_CHECK_SOULS = RuleImage(roi_front=(611,225,100,100), roi_back=(507,199,272,175), threshold=0.8, method="Template matching", file="./tasks/RichMan/mall/medal/medal_me_check_souls.png")
+
+
+	# Ocr Rule Assets
+	# Count sold-out labels in medal shop page 
+	O_SOLD_OUT = RuleOcr(roi=(0,100,1280,500), area=(0,100,1280,500), mode="Full", method="Default", keyword="售", name="sold_out")
 
 
 	# Image Rule Assets

--- a/tasks/RichMan/mall/medal.py
+++ b/tasks/RichMan/mall/medal.py
@@ -23,42 +23,101 @@ class Medal(FriendshipPoints):
             return
         self._enter_medal()
 
+        # 记录识别失败的商品，用于事后核对是否为售罄
+        not_found = []
+
         # 黑蛋
         if con.black_daruma:
-            self.buy_mall_one(buy_button=self.I_ME_BLACK, buy_check=self.I_ME_CHECK_BLACK,
-                              money_ocr=self.O_MALL_RESOURCE_3, buy_money=480)
+            self.screenshot()
+            if self.appear(self.I_ME_BLACK):
+                self.buy_mall_one(buy_button=self.I_ME_BLACK, buy_check=self.I_ME_CHECK_BLACK,
+                                  money_ocr=self.O_MALL_RESOURCE_3, buy_money=480)
+            else:
+                not_found.append('black_daruma')
         # 蓝票
         if con.mystery_amulet:
-            self.buy_mall_one(buy_button=self.I_ME_BLUE, buy_check=self.I_ME_CHECK_BLUE,
-                              money_ocr=self.O_MALL_RESOURCE_3, buy_money=180)
+            self.screenshot()
+            if self.appear(self.I_ME_BLUE):
+                self.buy_mall_one(buy_button=self.I_ME_BLUE, buy_check=self.I_ME_CHECK_BLUE,
+                                  money_ocr=self.O_MALL_RESOURCE_3, buy_money=180)
+            else:
+                not_found.append('mystery_amulet')
         # 体力100
         if con.ap_100:
-            self.buy_mall_one(buy_button=self.I_ME_AP, buy_check=self.I_ME_CHECK_AP,
-                              money_ocr=self.O_MALL_RESOURCE_3, buy_money=120)
+            self.screenshot()
+            if self.appear(self.I_ME_AP):
+                self.buy_mall_one(buy_button=self.I_ME_AP, buy_check=self.I_ME_CHECK_AP,
+                                  money_ocr=self.O_MALL_RESOURCE_3, buy_money=120)
+            else:
+                not_found.append('ap_100')
         # 随机御魂
         if con.random_soul:
-            self.buy_mall_one(buy_button=self.I_ME_SOULS, buy_check=self.I_ME_CHECK_SOULS,
-                              money_ocr=self.O_MALL_RESOURCE_3, buy_money=320)
+            self.screenshot()
+            if self.appear(self.I_ME_SOULS):
+                self.buy_mall_one(buy_button=self.I_ME_SOULS, buy_check=self.I_ME_CHECK_SOULS,
+                                  money_ocr=self.O_MALL_RESOURCE_3, buy_money=320)
+            else:
+                not_found.append('random_soul')
         # 两颗白蛋
         if con.white_daruma:
-            self.buy_mall_more(buy_button=self.I_ME_WHITE, remain_number=True, money_ocr=self.I_MALL_RESOURCE_MEDAL.build_mall_resource_ocr(self.device.image),
-                               buy_number=2, buy_max=2, buy_money=100)
+            self.screenshot()
+            if self.appear(self.I_ME_WHITE):
+                self.buy_mall_more(buy_button=self.I_ME_WHITE, remain_number=True, money_ocr=self.I_MALL_RESOURCE_MEDAL.build_mall_resource_ocr(self.device.image),
+                                   buy_number=2, buy_max=2, buy_money=100)
+            else:
+                not_found.append('white_daruma')
         # 十张挑战券
         if con.challenge_pass:
-            self.buy_mall_more(buy_button=self.I_ME_CHALLENGE_PASS, remain_number=True, money_ocr=self.I_MALL_RESOURCE_MEDAL.build_mall_resource_ocr(self.device.image),
-                               buy_number=con.challenge_pass, buy_max=10, buy_money=30)
+            self.screenshot()
+            if self.appear(self.I_ME_CHALLENGE_PASS):
+                self.buy_mall_more(buy_button=self.I_ME_CHALLENGE_PASS, remain_number=True, money_ocr=self.I_MALL_RESOURCE_MEDAL.build_mall_resource_ocr(self.device.image),
+                                   buy_number=con.challenge_pass, buy_max=10, buy_money=30)
+            else:
+                not_found.append('challenge_pass')
         # 红蛋
         if con.red_daruma:
-            self.buy_mall_more(buy_button=self.I_ME_RED, remain_number=False,
-                               money_ocr=self.I_MALL_RESOURCE_MEDAL.build_mall_resource_ocr(self.device.image),
-                               buy_number=con.red_daruma, buy_max=99, buy_money=30)
+            self.screenshot()
+            if self.appear(self.I_ME_RED):
+                self.buy_mall_more(buy_button=self.I_ME_RED, remain_number=False,
+                                   money_ocr=self.I_MALL_RESOURCE_MEDAL.build_mall_resource_ocr(self.device.image),
+                                   buy_number=con.red_daruma, buy_max=99, buy_money=30)
+            else:
+                not_found.append('red_daruma')
         # 破碎的咒符
         if con.broken_amulet:
-            self.buy_mall_more(buy_button=self.I_ME_BROKEN, remain_number=False,
-                               money_ocr=self.I_MALL_RESOURCE_MEDAL.build_mall_resource_ocr(self.device.image),
-                               buy_number=con.broken_amulet, buy_max=99, buy_money=20)
+            self.screenshot()
+            if self.appear(self.I_ME_BROKEN):
+                self.buy_mall_more(buy_button=self.I_ME_BROKEN, remain_number=False,
+                                   money_ocr=self.I_MALL_RESOURCE_MEDAL.build_mall_resource_ocr(self.device.image),
+                                   buy_number=con.broken_amulet, buy_max=99, buy_money=20)
+            else:
+                not_found.append('broken_amulet')
+
+        # 有识别失败的商品：核对售罄数量，确认失败是否为"商品售罄"（正常情况），而非页面异常。
+        # 注意：页面上的售罄标签可能包含未配置购买的商品，因此用 >= 而非 ==，避免误报。
+        if not_found:
+            self.screenshot()
+            soldout_count = self.count_soldout()
+            if soldout_count >= len(not_found):
+                logger.info(f'Medal: {len(not_found)} item(s) not detected, sold out count is {soldout_count}, '
+                            f'the not-detected items are sold out, skip normally')
+            else:
+                logger.warning(f'Medal: {len(not_found)} item(s) not detected, but sold out count is only {soldout_count}, '
+                               f'some items may not be sold out, page may be abnormal, please check manually')
 
         time.sleep(1)
+
+    def count_soldout(self) -> int:
+        """
+        统计勋章商店页面中"售罄"标签的数量。
+        通过 OCR 检测商品区域内含"售"字的文本块（售罄标签），用于核对识别失败的商品是否均为售罄。
+        需要先调用 screenshot 保证 self.device.image 为最新画面。
+        :return: 售罄标签数量
+        """
+        results = self.O_SOLD_OUT.detect_and_ocr(self.device.image, logDisplay=False)
+        count = sum(1 for r in results if '售' in r.ocr_text)
+        logger.info(f'Medal sold out count: {count}')
+        return count
 
 
 if __name__ == '__main__':

--- a/tasks/RichMan/mall/medal/ocr.json
+++ b/tasks/RichMan/mall/medal/ocr.json
@@ -1,0 +1,11 @@
+[
+  {
+    "itemName": "sold_out",
+    "roiFront": "0,100,1280,500",
+    "roiBack": "0,100,1280,500",
+    "mode": "Full",
+    "method": "Default",
+    "keyword": "售",
+    "description": "Count sold-out labels in medal shop page"
+  }
+]

--- a/tasks/RichMan/mall/navbar.py
+++ b/tasks/RichMan/mall/navbar.py
@@ -74,7 +74,8 @@ class MallNavbar(GameUi, RichManAssets):
         :return:
         """
         self._enter_sundry()
-        self.ui_click(self.I_SIDE_SURE_MEDAL, self.I_SIDE_CHECK_MEDAL)
+        # 增加超时保护：15秒内未出现勋章页确认则放弃，避免入口点击无效时无限循环
+        self.ui_click(self.I_SIDE_SURE_MEDAL, self.I_SIDE_CHECK_MEDAL, timeout=15)
 
     def _enter_charisma(self):
         """
@@ -89,7 +90,8 @@ class MallNavbar(GameUi, RichManAssets):
         返回商城
         :return:
         """
-        self.ui_click(self.I_UI_BACK_YELLOW, self.I_CHECK_MALL)
+        # 增加超时保护：15秒内未回到商城则放弃，避免界面异常时无限点击返回按钮导致卡死
+        self.ui_click(self.I_UI_BACK_YELLOW, self.I_CHECK_MALL, timeout=15)
 
     def mall_resource(self, index: int) -> int:
         """


### PR DESCRIPTION
## Problem
When items in the medal shop are sold out, their card templates no longer match (sold-out labels / greyed out), so all configured items fail detection. The script then blindly clicks the back button from the main screen and triggers GameStuckError -> game restart. Reproduced twice with identical stack (RichMan medal shop).

Root cause: no sold-out recognition; sold out (normal state) is treated as not found (abnormal), then wrong exit flow is taken.

## Fix
- Buy an item only when its card template is detected; otherwise record it as not-detected.
- After processing, OCR-count the sold-out labels in the shop area and verify the not-detected items are all sold out: sold_out_count >= not_found_count -> skip normally; sold_out_count < not_found_count -> warn page may be abnormal.
- Add timeout guard (15s) to _enter_medal and back_mall to avoid infinite click loops when the UI does not respond.

## Verification
- OCR count verified against real screenshots: 6 sold out -> count 6; 1 sold out -> count 1; bottom-nav excluded correctly.
- py_compile and module import passed.

## Sourcery 总结

妥善处理奖牌商店中已售罄的商品，并在界面无响应时保护商店导航流程。

错误修复：
- 处理已售罄的奖牌商店商品，不将其误判为缺少页面错误，也不会触发不必要的游戏重启。
- 当无法检测到的已配置商品数量与页面上已售罄标签的数量无法对应时发出警告。

功能增强：
- 添加基于 OCR 的已售罄商品计数，以验证奖牌商店商品检测结果。
- 进入奖牌商店和返回商城时添加 15 秒超时，防止 UI 交互循环无限期卡住。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

优雅地处理奖牌商店中的售罄商品，防止商店导航无响应而陷入无限交互循环。

错误修复：
- 处理售罄的奖牌商店商品，不将其视为缺失页面，也不会触发不必要的游戏重启。
- 当无法检测到的已配置商品与页面上售罄标签的数量无法对应时发出警告。

功能增强：
- 为无法检测到的奖牌商店商品添加基于 OCR 的验证，并为商店导航操作设置 15 秒超时保护。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

妥善处理奖牌商店中已售罄的商品，防止无响应的商店导航无限期停滞。

错误修复：
- 处理已售罄的奖牌商店商品，避免将其误判为缺失页面或触发不必要的游戏重启。
- 当无法将未检测到的已配置商品与商店的售罄标签对应时发出警告。

功能增强：
- 为未检测到的奖牌商店商品添加基于 OCR 的验证，并通过超时机制保护商店导航。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle sold-out medal shop items gracefully and prevent unresponsive shop navigation from stalling indefinitely.

Bug Fixes:
- Handle sold-out medal shop items without treating them as missing pages or triggering unnecessary game restarts.
- Warn when undetected configured items cannot be reconciled with the shop's sold-out labels.

Enhancements:
- Add OCR-based validation for undetected medal shop items and protect shop navigation with timeouts.

</details>

</details>

</details>