### PR TITLE
fix(GeneralBattle): retry prepare click after battle_before timeout

### DIFF
--- a/tasks/Component/GeneralBattle/general_battle.py
+++ b/tasks/Component/GeneralBattle/general_battle.py
@@ -38,7 +38,14 @@ class GeneralBattle(BattleWait, GeneralBuff):
         self.current_count += 1
         logger.info(f"Current count: {self.current_count}")
         # 战前设置
-        self.battle_before(buff, config)
+        if not self.battle_before(buff, config):
+            # battle_before 超时未进入战斗: 常见原因是点击"开始战斗"时被预设面板的关闭动画拦截,
+            # 点击未生效。此时画面已经稳定(面板动画已结束), 再识别一次:
+            # 若仍在战斗准备界面则再点击一次开始战斗, 若已进入战斗则直接继续。
+            if not self.retry_prepare_click():
+                logger.warning('battle_before failed: not in real battle within timeout, '
+                               'skip this battle and return False')
+                return False
         # 绿标
         if self.is_in_battle(False):
             self.green_mark(config.green_enable, config.green_mark)
@@ -75,6 +82,34 @@ class GeneralBattle(BattleWait, GeneralBuff):
                 continue
             # 未知界面, 既不是准备界面也不是战斗界面
             # logger.info('Wait for preparation page')  # 这玩意刷屏
+            sleep(random.uniform(0.4, 0.8))
+        return False
+
+    def retry_prepare_click(self, timeout: float = 3) -> bool:
+        """
+        battle_before 超时后的补偿: 再次识别画面并尝试开始战斗。
+        点击"开始战斗"可能被预设面板关闭动画拦截而未生效, 超时返回后画面已稳定,
+        此时若仍在战斗准备界面则再点击一次开始战斗; 若已进入战斗则直接成功。
+        :return: True: 超时内确认已进入真实战斗
+                 False: 超时仍未进入战斗(界面异常, 应由上层按战斗失败处理)
+        """
+        timer = Timer(timeout).start()
+        clicked = False  # 只补点一次, 避免在界面切换/点击延迟期间重复触发开始战斗
+        while not timer.reached():
+            self.screenshot()
+            if self.is_in_real_battle(False):  # 已经进入战斗
+                return True
+            if self.is_in_prepare(False):  # 仍在准备界面
+                if not clicked:
+                    clicked = True  # 只补点一次: 无论本次点击是否成功, 之后仅轮询
+                    if self.appear_then_click(self.I_PREPARE_HIGHLIGHT, interval=0.8):
+                        continue
+                    sleep(0.3)
+                    continue
+                # 已补点过一次, 只轮询等待进入战斗, 不再重复点击
+                sleep(0.3)
+                continue
+            # 未知界面, 等待画面变化
             sleep(random.uniform(0.4, 0.8))
         return False
 


### PR DESCRIPTION
## Problem
In RealmRaid (and other battles using run_general_battle), the start-battle click (GB_PREPARE_HIGHLIGHT) can be intercepted by the closing preset-panel animation right after switching preset team, so the battle never starts. battle_before() returns False after its 5s timeout, but the return value was ignored and run_general_battle still entered battle_wait()'s infinite loop waiting for a result screen that never appears - the script looks stuck with no action until the user manually clicks start.

Reproduced in real logs: 14:23:15.236 start click missed, battle_before returned False at 14:23:15.8, then the script waited in battle_wait until the user manually started the battle (won at 14:23:33).

## Fix
Keep the original logic untouched. After battle_before() times out, re-check the screen for up to 3s (retry_prepare_click):
- still on the prepare screen -> click start battle once more and wait for the battle to begin
- already in real battle -> continue normally
- neither (abnormal state) -> log a warning and return False so callers (e.g. RealmRaid, which uses last_battle to decide refresh/exit) handle it as a failed battle instead of waiting forever

## Verification
- py_compile and module import passed.
- Logic simulation: prepare->re-click->in battle returns True; stuck on prepare returns False; already in battle returns True. All PASS.

## Sourcery 摘要

在战斗开始前超时后重试启动普通战斗；当无法确认战斗状态时安全地中止。

Bug 修复：
- 当初始点击未被注册时，在战斗开始前超时后重试启动战斗操作。
- 当屏幕未进入有效的准备状态或战斗中状态时，干净地结束战斗，避免无限等待结果画面。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

让普通战斗能够从未成功点击开始按钮的情况中恢复，并在无法确认战斗状态时安全退出。

错误修复：
- 在战斗前阶段超时后重试开始普通战斗，以处理过渡 UI 动画导致的开始按钮点击未生效问题。
- 当屏幕未进入有效的准备状态或战斗中状态时，干净地中止战斗，避免无限等待结果画面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make general battles recover from missed start clicks and fail safely when the battle state cannot be confirmed.

Bug Fixes:
- Retry starting a general battle after the pre-battle phase times out, handling missed start clicks caused by transitional UI animations.
- Abort the battle cleanly when the screen does not reach a valid preparation or in-battle state, preventing indefinite waits for a result screen.

</details>

</details>