### PR TITLE
fix(DemonEncounter): 调整逢魔Boss挑战次数识别区域

### DIFF
--- a/tasks/DemonEncounter/assets.py
+++ b/tasks/DemonEncounter/assets.py
@@ -126,7 +126,7 @@ class DemonEncounterAssets:
 	# 计数已经开启多少的 
 	O_DE_COUNTER = RuleOcr(roi=(1204,685,48,34), area=(1204,685,48,34), mode="DigitCounter", method="Default", keyword="", name="de_counter")
 	# 现世逢魔顶部今日挑战次数X/1的最小识别区, 0/1表示已打过直接结束 
-	O_DE_CHALLENGE_COUNT = RuleOcr(roi=(680,68,75,36), area=(680,68,75,36), mode="Full", method="Default", keyword="", name="de_challenge_count")
+	O_DE_CHALLENGE_COUNT = RuleOcr(roi=(705,68,45,36), area=(705,68,45,36), mode="Full", method="Default", keyword="", name="de_challenge_count")
 
 
 	# Click Rule Assets

--- a/tasks/DemonEncounter/demon/ocr.json
+++ b/tasks/DemonEncounter/demon/ocr.json
@@ -10,8 +10,8 @@
   },
   {
     "itemName": "de_challenge_count",
-    "roiFront": "680,68,75,36",
-    "roiBack": "680,68,75,36",
+    "roiFront": "705,68,45,36",
+    "roiBack": "705,68,45,36",
     "mode": "Full",
     "method": "Default",
     "keyword": "",


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 修正逢魔Boss今日挑战次数的识别区域，提升已完成挑战状态的判断准确性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 修正逢魔Boss今日挑战次数的识别区域，提升已完成挑战状态的判断准确性。

</details>